### PR TITLE
Add first-pass core decision leaves

### DIFF
--- a/adapters/NODE.md
+++ b/adapters/NODE.md
@@ -59,6 +59,10 @@ All sessioned adapters share a common `sessionCodec` pattern that normalizes fie
 - **Skill injection via symlinks** into a temporary `.claude/skills/` directory. This avoids modifying the user's actual project while still making Paperclip skills discoverable by the agent's native skill system.
 - **Billing inference** is adapter-side. Each adapter reports `billingType`, `costUsd`, `provider`, and `biller` from its own output parsing, since different agents surface cost information differently.
 
+## Decision Records
+
+- [shared-server-adapter-contract.md](shared-server-adapter-contract.md) — Why all runtimes plug into one server adapter contract instead of baking provider-specific logic into the control plane.
+
 ---
 
 ## Sub-domains

--- a/adapters/shared-server-adapter-contract.md
+++ b/adapters/shared-server-adapter-contract.md
@@ -1,0 +1,40 @@
+---
+title: "Shared Server Adapter Contract"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Shared Server Adapter Contract
+
+Paperclip supports multiple agent runtimes, but the control plane should not
+special-case each runtime everywhere in the server and UI.
+
+## Decision
+
+Every runtime integrates through a shared server-side adapter contract. The
+adapter owns runtime-specific execution, environment checks, skill syncing,
+session serialization, quota discovery, model detection, and optional
+configuration schema. The control plane consumes that contract instead of
+coding directly against individual CLIs or gateways.
+
+## Why
+
+This keeps orchestration logic vendor-agnostic. Local CLIs, remote gateways,
+and future providers can all plug into the same lifecycle without rewriting
+task orchestration, approvals, cost tracking, or frontend management flows.
+
+## Implications
+
+- Adding a new runtime should usually mean adding one adapter package plus any
+  parser or UI wiring it needs, not rewriting core orchestration.
+- Runtime-specific concerns such as quota APIs, credential discovery, and skill
+  installation stay inside the adapter boundary.
+- Session resume semantics are normalized through shared codec and session
+  management metadata, so the control plane can reason about continuity without
+  knowing each runtime's native format.
+- The frontend can render adapter settings from declarative config schemas
+  rather than bespoke forms for every provider.
+
+## Related Domains
+
+- [engineering backend](../engineering/backend/NODE.md)
+- [engineering frontend](../engineering/frontend/NODE.md)

--- a/engineering/database/NODE.md
+++ b/engineering/database/NODE.md
@@ -74,3 +74,7 @@ For local development and single-user deployments, the DB package supports start
 - **Single database, query-level isolation.** Multi-tenancy is simple and avoids operational complexity of per-tenant databases.
 - **Backup/restore built in.** The DB package includes `pg_dump`/`pg_restore` wrappers for data portability.
 - **No ORM abstraction layer.** Services use Drizzle's query builder directly — no repository pattern wrapping it.
+
+## Decision Records
+
+- [company-scoped-isolation.md](company-scoped-isolation.md) — Why Paperclip keeps multi-company data in one schema while treating `company_id` as a hard isolation boundary across schema, auth, and service logic.

--- a/engineering/database/company-scoped-isolation.md
+++ b/engineering/database/company-scoped-isolation.md
@@ -1,0 +1,43 @@
+---
+title: "Company-Scoped Isolation"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Company-Scoped Isolation
+
+Paperclip runs multiple companies inside one control-plane deployment, but it
+does not treat those companies as soft organizational labels. Company identity
+is a load-bearing system boundary.
+
+## Decision
+
+Use a single PostgreSQL schema and enforce isolation by carrying `company_id`
+through company-scoped tables, actor resolution, and service-layer queries.
+Paperclip does not use a separate database per company, and it does not rely
+on database row-level security as the primary isolation mechanism.
+
+## Why
+
+This keeps the platform operationally simple for local-first and small-team
+deployments while preserving the product model that one Paperclip instance can
+host multiple independent companies. It also keeps cross-company operations,
+instance admin workflows, and shared infrastructure manageable without adding
+tenant-per-database complexity.
+
+## Implications
+
+- New domain tables that belong to a company should carry `company_id` and be
+  indexed in company-aware access patterns.
+- Authentication and actor resolution must always produce company context for
+  agent and board actions before service logic runs.
+- Isolation bugs are application bugs, not something the database will
+  automatically rescue. Service code has to treat company scoping as a first
+  principle.
+- Features that introduce shared infrastructure, such as execution workspaces,
+  costs, or approvals, still need an explicit answer for how company context is
+  attached and enforced.
+
+## Related Domains
+
+- [company-model](../../product/company-model/NODE.md)
+- [backend](../backend/NODE.md)

--- a/product/governance/NODE.md
+++ b/product/governance/NODE.md
@@ -87,6 +87,10 @@ Every mutation writes to `activity_log`. Every approval decision is logged. Agen
 - Role-based human permission granularity
 - Fine-grained per-action governance gates beyond hire and strategy approval
 
+## Decision Records
+
+- [server-enforced-approvals-and-budget-stops.md](server-enforced-approvals-and-budget-stops.md) — Why approvals, budget hard stops, and their audit trail are enforced in the server rather than delegated to agents or adapters.
+
 ## Open Questions
 
 - What governance-gated actions exist beyond hiring and CEO strategy approval?

--- a/product/governance/server-enforced-approvals-and-budget-stops.md
+++ b/product/governance/server-enforced-approvals-and-budget-stops.md
@@ -1,0 +1,40 @@
+---
+title: "Server-Enforced Approvals And Budget Stops"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Server-Enforced Approvals And Budget Stops
+
+Paperclip's governance model only works if approval gates and budget ceilings
+remain control-plane invariants instead of runtime conventions.
+
+## Decision
+
+Approval resolution, budget policy enforcement, pause/resume state changes, and
+their audit consequences are enforced in server services. Agents and adapters
+can request actions and report usage, but they do not get to finalize approval
+outcomes or decide whether governance rules apply.
+
+## Why
+
+This preserves board authority even when many different runtimes are executing
+work. It also ensures that the same governance rules hold across local
+development, authenticated deployments, and future runtime integrations.
+
+## Implications
+
+- Approval types such as hiring remain canonical server objects whose state
+  transitions decide whether downstream mutations are applied.
+- Budget hard stops pause the affected scope in the platform state model and
+  can cancel work, rather than relying on runtimes to self-regulate.
+- Auditability depends on the server being the mutation authority for these
+  flows, because the activity log and approval records are part of the product
+  contract.
+- New features that spend money, create authority, or change execution rights
+  must integrate with the server governance path instead of bypassing it.
+
+## Related Domains
+
+- [engineering backend](../../engineering/backend/NODE.md)
+- [company model](../company-model/NODE.md)
+- [agent model](../agent-model/NODE.md)


### PR DESCRIPTION
## Summary
- add first-pass leaf decision records for company-scoped isolation, the shared adapter contract, and server-enforced governance
- link those new leaves from the database, adapters, and governance domain nodes

## Source of truth used
- `.paperclip/packages/db/src/schema/agents.ts`
- `.paperclip/packages/db/src/schema/issues.ts`
- `.paperclip/server/src/middleware/auth.ts`
- `.paperclip/packages/adapter-utils/src/types.ts`
- `.paperclip/packages/adapter-utils/src/session-compaction.ts`
- `.paperclip/packages/adapters/codex-local/src/server/index.ts`
- `.paperclip/server/src/services/approvals.ts`
- `.paperclip/server/src/services/budgets.ts`

## Verification
- `npx -y -p first-tree first-tree verify --tree-path .`

## Review note
- touched domains are owned by `cryppadotta` / `serenakeyitan`, so owner review is appropriate