### PR TITLE
Generate CODEOWNERS from tree ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,40 @@
+# Auto-generated from Context Tree. Do not edit manually.
+
+/*                                                 @serenakeyitan
+/adapters/                                         @cryppadotta @serenakeyitan
+/adapters/shared-server-adapter-contract.md        @cryppadotta @serenakeyitan
+/adapters/claude-local/                            @cryppadotta @serenakeyitan
+/adapters/codex-local/                             @cryppadotta @serenakeyitan
+/adapters/cursor-local/                            @cryppadotta @serenakeyitan
+/adapters/gemini-local/                            @cryppadotta @serenakeyitan
+/adapters/openclaw-gateway/                        @cryppadotta @serenakeyitan
+/adapters/opencode-local/                          @cryppadotta @serenakeyitan
+/adapters/pi-local/                                @cryppadotta @serenakeyitan
+/engineering/                                      @cryppadotta @serenakeyitan
+/engineering/backend/                              @cryppadotta @serenakeyitan
+/engineering/cli/                                  @cryppadotta @serenakeyitan
+/engineering/database/                             @cryppadotta @serenakeyitan
+/engineering/database/company-scoped-isolation.md  @cryppadotta @serenakeyitan
+/engineering/frontend/                             @cryppadotta @serenakeyitan
+/engineering/shared/                               @cryppadotta @serenakeyitan
+/infrastructure/                                   @cryppadotta @serenakeyitan
+/infrastructure/ci-cd/                             @cryppadotta @serenakeyitan
+/infrastructure/deployment/                        @cryppadotta @serenakeyitan
+/infrastructure/testing/                           @cryppadotta @serenakeyitan
+/members/                                          @serenakeyitan
+/members/devinfoley/                               @devinfoley
+/members/dotta/                                    @cryppadotta
+/members/henkdz/                                   @HenkDz
+/members/mvanhorn/                                 @mvanhorn
+/members/serenakeyitan/                            @serenakeyitan
+/members/zvictor/                                  @zvictor
+/plugins/                                          @cryppadotta @serenakeyitan
+/plugins/examples/                                 @cryppadotta @serenakeyitan
+/plugins/runtime/                                  @cryppadotta @serenakeyitan
+/plugins/sdk/                                      @cryppadotta @serenakeyitan
+/product/                                          @cryppadotta @serenakeyitan
+/product/agent-model/                              @cryppadotta @serenakeyitan
+/product/company-model/                            @cryppadotta @serenakeyitan
+/product/governance/                               @cryppadotta @serenakeyitan
+/product/governance/server-enforced-approvals-and-budget-stops.md @cryppadotta @serenakeyitan
+/product/task-system/                              @cryppadotta @serenakeyitan


### PR DESCRIPTION
## Summary
- generate `.github/CODEOWNERS` from the current Context Tree ownership graph
- make repo review routing follow the tree instead of relying on manual upkeep

## Verification
- `npx -y -p first-tree first-tree verify --tree-path .`
- `npx -y -p first-tree first-tree generate-codeowners --check`