### PR TITLE
Add runtime and auth decision leaves

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 /adapters/pi-local/                                @cryppadotta @serenakeyitan
 /engineering/                                      @cryppadotta @serenakeyitan
 /engineering/backend/                              @cryppadotta @serenakeyitan
+/engineering/backend/shared-api-and-actor-scoped-authorization.md @cryppadotta @serenakeyitan
 /engineering/cli/                                  @cryppadotta @serenakeyitan
 /engineering/database/                             @cryppadotta @serenakeyitan
 /engineering/database/company-scoped-isolation.md  @cryppadotta @serenakeyitan
@@ -31,6 +32,7 @@
 /plugins/                                          @cryppadotta @serenakeyitan
 /plugins/examples/                                 @cryppadotta @serenakeyitan
 /plugins/runtime/                                  @cryppadotta @serenakeyitan
+/plugins/runtime/worker-isolation-and-capability-gates.md @cryppadotta @serenakeyitan
 /plugins/sdk/                                      @cryppadotta @serenakeyitan
 /product/                                          @cryppadotta @serenakeyitan
 /product/agent-model/                              @cryppadotta @serenakeyitan

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -63,3 +63,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 - **Drizzle queries live in services, not a separate "repository" layer.** This keeps the codebase flat and avoids over-abstraction.
 - **Agent execution is adapter-driven.** The server never calls LLM APIs directly — it delegates to adapter packages that implement a standard interface.
 - **Secrets are provider-abstracted.** Supports file-based, environment-based, and external secret providers so the same server code works in local dev and cloud deployments.
+
+## Decision Records
+
+- [shared-api-and-actor-scoped-authorization.md](shared-api-and-actor-scoped-authorization.md) — Why board and agent traffic share one API surface, with authorization derived from a common request actor model.

--- a/engineering/backend/shared-api-and-actor-scoped-authorization.md
+++ b/engineering/backend/shared-api-and-actor-scoped-authorization.md
@@ -1,0 +1,42 @@
+---
+title: "Shared API And Actor-Scoped Authorization"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Shared API And Actor-Scoped Authorization
+
+Paperclip does not maintain one HTTP surface for humans and another for agents.
+The backend uses a shared API surface and makes authorization a property of the
+resolved actor on each request.
+
+## Decision
+
+Resolve request actors centrally in middleware, then apply company access and
+role-specific checks at the route layer. Board sessions, board API keys, agent
+API keys, and local agent JWTs all flow into the same request actor model, and
+routes decide what the resolved actor may do.
+
+## Why
+
+This keeps the control plane easier to reason about than separate "board API"
+and "agent API" products. It also preserves one canonical way to express
+company access, instance-admin overrides, agent scoping, and deployment-mode
+guards across the server.
+
+## Implications
+
+- New routes should consume `req.actor` plus shared auth helpers instead of
+  inventing ad hoc credential parsing or role checks.
+- Company scoping is enforced before feature-specific permissions, so agent and
+  human requests stay inside the same company boundary model.
+- Deployment-specific protections such as trusted browser mutation checks and
+  private-hostname gating layer on top of the same actor model rather than
+  replacing it.
+- Product decisions about who may invoke a route should usually become route
+  assertions or access-service checks, not a separate API namespace.
+
+## Related Domains
+
+- [database](../database/NODE.md)
+- [product governance](../../product/governance/NODE.md)
+- [product company model](../../product/company-model/NODE.md)

--- a/plugins/runtime/NODE.md
+++ b/plugins/runtime/NODE.md
@@ -38,6 +38,10 @@ Provide a secure, observable, and resilient execution environment for third-part
 - **Event-driven coordination.** The lifecycle manager emits events (`plugin.loaded`, `plugin.enabled`, etc.) that other services listen to. The job coordinator pauses jobs when a plugin moves out of `ready` state. The tool dispatcher deregisters tools when a plugin is disabled.
 - **Database-backed state.** Plugin state, entities, job runs, and webhook deliveries are persisted in PostgreSQL tables with `pluginId` scoping, not in-memory. This survives server restarts.
 
+## Decision Records
+
+- [worker-isolation-and-capability-gates.md](worker-isolation-and-capability-gates.md) — Why plugin workers are isolated out of process and why the host enforces declared capabilities at install-time and runtime.
+
 ## Boundaries
 
 This domain covers the host-side services that implement the plugin execution contract. The contract itself (types, protocol, SDK API) is defined in `../sdk`. Route handlers that expose plugin management over HTTP live in `../../engineering/backend`. Database schema and migrations live in `../../engineering/database`.

--- a/plugins/runtime/worker-isolation-and-capability-gates.md
+++ b/plugins/runtime/worker-isolation-and-capability-gates.md
@@ -1,0 +1,43 @@
+---
+title: "Worker Isolation And Capability Gates"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Worker Isolation And Capability Gates
+
+Paperclip's plugin runtime is intentionally not an in-process extension model.
+The host treats plugin execution as a separate boundary that needs both failure
+isolation and explicit permission checks.
+
+## Decision
+
+Run each active plugin in its own worker process and enforce plugin
+capabilities at the host boundary, both when a plugin is installed and when a
+worker calls back into host services at runtime.
+
+## Why
+
+This keeps a plugin crash, hang, or bad dependency from taking down the core
+server, and it keeps host-side power concentrated in one place instead of
+trusting every plugin call path to self-police. The runtime can therefore
+support richer extensions without collapsing the control plane into a shared
+process and permission model.
+
+## Implications
+
+- The host-worker protocol is a real operational boundary, not just an
+  implementation detail. Timeouts, restart policy, and graceful shutdown are
+  part of the product contract.
+- Capability checks have to happen where the host receives an operation, so the
+  same rules apply regardless of which plugin SDK helpers or custom code paths
+  produced the request.
+- Plugin authors can build substantial integrations, but they do so through a
+  constrained bridge rather than direct access to host internals.
+- Expanding the plugin surface usually means defining new host operations and
+  their capability mapping, not bypassing the gate.
+
+## Related Domains
+
+- [plugin sdk](../sdk/NODE.md)
+- [engineering backend](../../engineering/backend/NODE.md)
+- [engineering database](../../engineering/database/NODE.md)


### PR DESCRIPTION
## Summary
- add leaf decision records for plugin worker isolation/capability gates and for the shared API actor-authorization model
- link those new leaves from the backend and plugin runtime domain nodes
- refresh `.github/CODEOWNERS` for the new ownership targets

## Source of truth used
- `.paperclip/server/src/services/plugin-capability-validator.ts`
- `.paperclip/server/src/services/plugin-worker-manager.ts`
- `.paperclip/server/src/middleware/auth.ts`
- `.paperclip/server/src/routes/authz.ts`
- `.paperclip/server/src/routes/companies.ts`
- `.paperclip/server/src/routes/issues.ts`
- `.paperclip/server/src/middleware/board-mutation-guard.ts`
- `.paperclip/server/src/app.ts`

## Verification
- `npx -y -p first-tree first-tree verify --tree-path .`
- `npx -y -p first-tree first-tree generate-codeowners --check`