### PR TITLE
Add README and first-pass decision records

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,23 +5,31 @@
 /adapters/shared-server-adapter-contract.md        @cryppadotta @serenakeyitan
 /adapters/claude-local/                            @cryppadotta @serenakeyitan
 /adapters/codex-local/                             @cryppadotta @serenakeyitan
+/adapters/codex-local/rpc-quota-and-fresh-skill-injection.md @cryppadotta @serenakeyitan
 /adapters/cursor-local/                            @cryppadotta @serenakeyitan
 /adapters/gemini-local/                            @cryppadotta @serenakeyitan
 /adapters/openclaw-gateway/                        @cryppadotta @serenakeyitan
+/adapters/openclaw-gateway/websocket-gateway-and-device-pairing.md @cryppadotta @serenakeyitan
 /adapters/opencode-local/                          @cryppadotta @serenakeyitan
 /adapters/pi-local/                                @cryppadotta @serenakeyitan
 /engineering/                                      @cryppadotta @serenakeyitan
 /engineering/backend/                              @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @cryppadotta @serenakeyitan
 /engineering/cli/                                  @cryppadotta @serenakeyitan
+/engineering/cli/cli-mirrors-api-and-instance-ops.md @cryppadotta @serenakeyitan
 /engineering/database/                             @cryppadotta @serenakeyitan
 /engineering/database/company-scoped-isolation.md  @cryppadotta @serenakeyitan
 /engineering/frontend/                             @cryppadotta @serenakeyitan
+/engineering/frontend/api-layer-and-react-query-over-global-state.md @cryppadotta @serenakeyitan
 /engineering/shared/                               @cryppadotta @serenakeyitan
+/engineering/shared/const-arrays-and-zero-runtime-dependencies.md @cryppadotta @serenakeyitan
 /infrastructure/                                   @cryppadotta @serenakeyitan
 /infrastructure/ci-cd/                             @cryppadotta @serenakeyitan
+/infrastructure/ci-cd/ci-owns-the-lockfile.md      @cryppadotta @serenakeyitan
 /infrastructure/deployment/                        @cryppadotta @serenakeyitan
+/infrastructure/deployment/authenticated-docker-and-local-trusted-dev.md @cryppadotta @serenakeyitan
 /infrastructure/testing/                           @cryppadotta @serenakeyitan
+/infrastructure/testing/no-llm-calls-in-default-ci.md @cryppadotta @serenakeyitan
 /members/                                          @serenakeyitan
 /members/devinfoley/                               @devinfoley
 /members/dotta/                                    @cryppadotta
@@ -31,12 +39,18 @@
 /members/zvictor/                                  @zvictor
 /plugins/                                          @cryppadotta @serenakeyitan
 /plugins/examples/                                 @cryppadotta @serenakeyitan
+/plugins/examples/examples-live-in-tree-as-sdk-contract-tests.md @cryppadotta @serenakeyitan
 /plugins/runtime/                                  @cryppadotta @serenakeyitan
 /plugins/runtime/worker-isolation-and-capability-gates.md @cryppadotta @serenakeyitan
 /plugins/sdk/                                      @cryppadotta @serenakeyitan
+/plugins/sdk/single-sdk-dependency-and-zod-reexports.md @cryppadotta @serenakeyitan
 /product/                                          @cryppadotta @serenakeyitan
 /product/agent-model/                              @cryppadotta @serenakeyitan
+/product/agent-model/adapter-defined-agent-internals.md @cryppadotta @serenakeyitan
 /product/company-model/                            @cryppadotta @serenakeyitan
+/product/company-model/company-is-the-top-level-boundary.md @cryppadotta @serenakeyitan
 /product/governance/                               @cryppadotta @serenakeyitan
 /product/governance/server-enforced-approvals-and-budget-stops.md @cryppadotta @serenakeyitan
 /product/task-system/                              @cryppadotta @serenakeyitan
+/product/task-system/tasks-are-the-communication-channel.md @cryppadotta @serenakeyitan
+/README.md                                         @serenakeyitan

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+---
+title: "Paperclip Context Tree"
+owners: [serenakeyitan]
+---
+
+# Paperclip Context Tree
+
+This repository is the dedicated **Context Tree** for Paperclip.
+
+It is the living source of truth for **decisions, constraints, ownership, and
+cross-domain relationships** around the Paperclip project. It is **not** the
+implementation repo and it is **not** the place for low-level execution detail.
+
+**Source repository:** [paperclipai/paperclip](https://github.com/paperclipai/paperclip)
+
+## What Lives Here
+
+- Domain maps and boundaries
+- Architectural and product decisions
+- Ownership and review responsibility
+- Cross-domain links that future agents and humans need in order to decide well
+
+## What Does Not Live Here
+
+- Function signatures and internal APIs
+- Database schemas and migrations
+- UI component implementation details
+- Adapter parser code or workflow YAML internals
+
+Those belong in the source repository. This tree captures the **why** and the
+**how domains connect**.
+
+## Start Here
+
+1. Read [NODE.md](NODE.md) for the top-level map.
+2. Open the domain `NODE.md` that matches your task.
+3. Read the leaf decision records linked from that domain.
+4. Follow any related-domain links when the decision crosses boundaries.
+
+If you are working as an agent, also read:
+
+- [AGENTS.md](AGENTS.md)
+- [CLAUDE.md](CLAUDE.md)
+
+## Current Maturity
+
+This tree is currently in a **first-pass / baseline coverage** state:
+
+- Root and major domains are established
+- Member ownership is defined
+- Validation and CODEOWNERS generation are in place
+- Initial decision records exist for the most important product, engineering,
+  infrastructure, plugin, and adapter concerns
+
+The tree is usable today, but it is still being deepened. Some domains have
+rich `NODE.md` summaries but fewer leaf decision records than they should in a
+mature state.
+
+## Domain Map
+
+- [engineering/](engineering/NODE.md) — backend, frontend, database, shared
+  contracts, and CLI
+- [adapters/](adapters/NODE.md) — runtime integrations for Codex, Claude,
+  Cursor, Gemini, OpenClaw, OpenCode, and Pi
+- [plugins/](plugins/NODE.md) — plugin SDK, runtime boundary, and examples
+- [product/](product/NODE.md) — company model, agent model, task system, and
+  governance
+- [infrastructure/](infrastructure/NODE.md) — deployment, CI/CD, and testing
+- [members/](members/NODE.md) — owners and contributors
+
+## File Conventions
+
+- Every domain directory contains a `NODE.md`.
+- `NODE.md` explains the domain's purpose, boundaries, and major decisions.
+- Leaf markdown files under a domain capture a specific decision in a stable,
+  linkable form.
+- `owners` in frontmatter define who approves changes.
+- `soft_links` connect related domains without turning the tree into a full
+  graph database.
+
+## Common Commands
+
+```bash
+npx -p first-tree first-tree inspect --json
+npx -p first-tree first-tree verify
+npx -p first-tree first-tree generate-codeowners
+npx -p first-tree first-tree inject-context
+```
+
+## Working Rule
+
+Decide in the tree, execute in the source repo.
+
+If a task changes a decision, constraint, ownership boundary, or cross-domain
+relationship, update this tree. If a task changes only implementation detail,
+update the source repo instead.

--- a/adapters/codex-local/NODE.md
+++ b/adapters/codex-local/NODE.md
@@ -31,6 +31,10 @@ Adapter for **Codex CLI** (OpenAI's coding agent). Spawns `codex` as a local chi
 - **RPC-based quota** (`fetchCodexRpcQuota`) instead of scraping CLI output. This provides structured rate-limit window data with reset times.
 - **Skill injection before execution** via `ensureCodexSkillsInjected` rather than at skill-sync time. This ensures skills are always fresh for each run.
 
+## Decision Records
+
+- [rpc-quota-and-fresh-skill-injection.md](rpc-quota-and-fresh-skill-injection.md) — Why Codex quota comes from RPC and Paperclip skills are refreshed on the execution path.
+
 ---
 
 ## Boundaries

--- a/adapters/codex-local/rpc-quota-and-fresh-skill-injection.md
+++ b/adapters/codex-local/rpc-quota-and-fresh-skill-injection.md
@@ -1,0 +1,39 @@
+---
+title: "RPC Quota And Fresh Skill Injection"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# RPC Quota And Fresh Skill Injection
+
+The Codex adapter needs live operational information and reliable skill state,
+but both concerns become brittle if Paperclip depends on scraped terminal text
+or stale synced files.
+
+## Decision
+
+Use Codex RPC endpoints for quota discovery and inject Paperclip skills
+immediately before execution. Treat Codex as a runtime with confirmed native
+context management rather than applying Paperclip's generic compaction logic.
+
+## Why
+
+Structured RPC quota responses are more reliable than parsing human-readable CLI
+output, and pre-run skill injection keeps the runtime's task-facing behavior
+fresh even when local skill state has drifted.
+
+## Implications
+
+- The control plane can surface quota windows and reset timing without relying
+  on fragile text parsing.
+- Skill freshness becomes part of the execution path, reducing cases where the
+  adapter runs with outdated Paperclip instructions.
+- Session resume semantics still flow through Paperclip's shared adapter
+  contract, but context-window policy stays native to Codex.
+- Operational errors such as unknown-session handling remain adapter concerns,
+  not backend special cases.
+
+## Related Domains
+
+- [adapters](../NODE.md)
+- [engineering backend](../../engineering/backend/NODE.md)
+- [product agent model](../../product/agent-model/NODE.md)

--- a/adapters/openclaw-gateway/NODE.md
+++ b/adapters/openclaw-gateway/NODE.md
@@ -33,6 +33,10 @@ Adapter for **OpenClaw** agents via the WebSocket gateway protocol. Unlike all o
 - **No skill sync.** OpenClaw agents manage their own capabilities remotely. Paperclip does not inject skills into gateway-mode agents.
 - **No session codec exported.** Unlike local adapters, session state is managed server-side by the OpenClaw gateway.
 
+## Decision Records
+
+- [websocket-gateway-and-device-pairing.md](websocket-gateway-and-device-pairing.md) — Why OpenClaw is modeled as a gateway protocol with pairing and remote session routing.
+
 ---
 
 ## Boundaries

--- a/adapters/openclaw-gateway/websocket-gateway-and-device-pairing.md
+++ b/adapters/openclaw-gateway/websocket-gateway-and-device-pairing.md
@@ -1,0 +1,38 @@
+---
+title: "WebSocket Gateway And Device Pairing"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# WebSocket Gateway And Device Pairing
+
+OpenClaw is the clearest case where Paperclip is integrating with a remote
+runtime boundary rather than spawning a local coding CLI.
+
+## Decision
+
+Integrate OpenClaw through a WebSocket gateway protocol with device identity,
+pairing, and session-key strategies instead of treating it like a local
+child-process adapter.
+
+## Why
+
+The OpenClaw model depends on bidirectional event streaming, remote challenge
+flows, and device authorization semantics that do not map cleanly onto a
+start-process-read-stdout pattern.
+
+## Implications
+
+- Session routing is a protocol choice (`issue`, `fixed`, `run`), not just a
+  local process resume token.
+- Skill injection is intentionally absent because remote OpenClaw workers own
+  their capabilities on the other side of the gateway.
+- The adapter's operational surface centers on connectivity, pairing, and
+  auth configuration rather than local binary installation.
+- Gateway adapters remain first-class citizens in the shared adapter model even
+  though they do not share every local-adapter capability.
+
+## Related Domains
+
+- [adapters](../NODE.md)
+- [engineering backend](../../engineering/backend/NODE.md)
+- [product agent model](../../product/agent-model/NODE.md)

--- a/engineering/cli/NODE.md
+++ b/engineering/cli/NODE.md
@@ -56,3 +56,7 @@ A set of subcommands that call the Paperclip HTTP API for programmatic control:
 - **Client commands mirror the REST API.** Every major API resource has a corresponding CLI subcommand, making the CLI a complete alternative to the web UI for automation.
 - **Data directory isolation** (`--data-dir` flag). Allows running multiple isolated Paperclip instances on the same machine by overriding the default `~/.paperclip` data root.
 - **Telemetry is opt-in** and shares the same event schema as the server (via `@paperclipai/shared`).
+
+## Decision Records
+
+- [cli-mirrors-api-and-instance-ops.md](cli-mirrors-api-and-instance-ops.md) — Why the CLI is both the local instance operator surface and the resource-oriented API client.

--- a/engineering/cli/cli-mirrors-api-and-instance-ops.md
+++ b/engineering/cli/cli-mirrors-api-and-instance-ops.md
@@ -1,0 +1,39 @@
+---
+title: "CLI Mirrors The API And Owns Local Instance Operations"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# CLI Mirrors The API And Owns Local Instance Operations
+
+Paperclip's CLI is not only a thin wrapper around local scripts, and it is not
+only a remote API client. It intentionally does both jobs.
+
+## Decision
+
+Use the CLI as the operator-facing command surface for two categories of work:
+local instance lifecycle operations and resource-oriented API client commands
+that mirror the server's major HTTP surfaces.
+
+## Why
+
+This lets one tool cover first-run onboarding, diagnostics, local execution,
+and headless automation without forcing operators into the browser for routine
+control-plane tasks. It also keeps Paperclip scriptable in CI, shell
+automation, and dev workflows.
+
+## Implications
+
+- New major server resources should usually get corresponding client
+  subcommands instead of remaining UI-only.
+- Local-only concerns such as `onboard`, `doctor`, `run`, and `worktree`
+  belong in the CLI because they interact with the operator's machine rather
+  than only the remote control plane.
+- Shared request and config schemas should live in `@paperclipai/shared` so the
+  CLI does not drift from server expectations.
+- The CLI is part of the product surface, not a secondary developer utility.
+
+## Related Domains
+
+- [engineering backend](../backend/NODE.md)
+- [engineering shared](../shared/NODE.md)
+- [infrastructure deployment](../../infrastructure/deployment/NODE.md)

--- a/engineering/frontend/NODE.md
+++ b/engineering/frontend/NODE.md
@@ -54,3 +54,7 @@ Pages live in `/ui/src/pages/` and map to top-level routes:
 - **UI is pre-built and published as an npm package** (`@paperclipai/ui`). The server can serve it as static assets or proxy to a Vite dev server during development.
 - **Tailwind v4** (not v3) — uses the new CSS-first configuration approach.
 - **Adapter UI components are co-located with adapter packages** but imported into the main UI bundle for the management pages.
+
+## Decision Records
+
+- [api-layer-and-react-query-over-global-state.md](api-layer-and-react-query-over-global-state.md) — Why frontend data flow is organized around a shared API layer plus React Query instead of a global store.

--- a/engineering/frontend/api-layer-and-react-query-over-global-state.md
+++ b/engineering/frontend/api-layer-and-react-query-over-global-state.md
@@ -1,0 +1,38 @@
+---
+title: "API Layer And React Query Over Global State"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# API Layer And React Query Over Global State
+
+Paperclip's UI needs to show a large, fast-changing control plane without
+turning the frontend into a second backend or a tangle of ad hoc fetch logic.
+
+## Decision
+
+Centralize HTTP calls in a dedicated API layer and manage server state with
+React Query plus domain hooks and context providers, instead of introducing a
+global state library such as Redux or Zustand.
+
+## Why
+
+This keeps data fetching, invalidation, and loading/error handling close to the
+actual server resources while keeping UI-only state separate. It matches the
+shape of a control-plane product better than a single app-wide mutable store.
+
+## Implications
+
+- Components should not call `fetch` directly when a shared API client or hook
+  belongs in `/ui/src/api` or `/ui/src/hooks`.
+- Server-derived state lives in query caches; UI-only concerns live in React
+  context or local component state.
+- Backend contract changes should usually surface first in the API layer rather
+  than being reimplemented independently across many pages.
+- Adapter-specific management surfaces can remain co-located with adapter code
+  while still participating in the same frontend data flow.
+
+## Related Domains
+
+- [engineering backend](../backend/NODE.md)
+- [engineering shared](../shared/NODE.md)
+- [adapters](../../adapters/NODE.md)

--- a/engineering/shared/NODE.md
+++ b/engineering/shared/NODE.md
@@ -50,3 +50,7 @@ Shared configuration shape used by both server and CLI.
 - **Const arrays, not TypeScript enums.** All domain values are `as const` arrays, which enables both type inference (`typeof X[number]`) and runtime iteration/validation. TypeScript enums are avoided.
 - **No runtime dependencies.** This package has zero npm dependencies — it is pure TypeScript types and constants. This keeps it safe to import anywhere without bloating bundles.
 - **Telemetry types are co-located** (`/src/telemetry/`) so both server and CLI share the same event schemas.
+
+## Decision Records
+
+- [const-arrays-and-zero-runtime-dependencies.md](const-arrays-and-zero-runtime-dependencies.md) — Why shared contracts are expressed with const arrays and kept dependency-free.

--- a/engineering/shared/const-arrays-and-zero-runtime-dependencies.md
+++ b/engineering/shared/const-arrays-and-zero-runtime-dependencies.md
@@ -1,0 +1,39 @@
+---
+title: "Const Arrays And Zero Runtime Dependencies"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Const Arrays And Zero Runtime Dependencies
+
+The shared package is the contract layer that every major Paperclip package can
+import safely. That only works if it stays small, portable, and runtime-light.
+
+## Decision
+
+Model shared domain vocabulary with `as const` arrays plus exported types and
+validators, and keep `@paperclipai/shared` free of third-party runtime
+dependencies.
+
+## Why
+
+This gives Paperclip one canonical definition of statuses, kinds, schema
+shapes, and configuration contracts that can be used by backend, frontend, CLI,
+database code, and adapters without bundle bloat or dependency cycles.
+
+## Implications
+
+- New cross-package enums, statuses, and request/response shapes should be
+  introduced here before being duplicated elsewhere.
+- Shared should hold contracts and validation helpers, not business logic that
+  depends on server or UI internals.
+- Importing shared remains safe in build scripts, browser bundles, adapters,
+  and command-line entrypoints.
+- Const-array patterns win over TypeScript enums because they support both
+  runtime iteration and type inference from the same source of truth.
+
+## Related Domains
+
+- [engineering backend](../backend/NODE.md)
+- [engineering frontend](../frontend/NODE.md)
+- [engineering cli](../cli/NODE.md)
+- [plugins sdk](../../plugins/sdk/NODE.md)

--- a/infrastructure/ci-cd/NODE.md
+++ b/infrastructure/ci-cd/NODE.md
@@ -70,6 +70,10 @@ The PR pipeline validates that every workspace `package.json` is listed in the D
 - Docker: cancel-in-progress per ref
 - Lockfile refresh: no cancel-in-progress (only one refresh at a time)
 
+## Decision Records
+
+- [ci-owns-the-lockfile.md](ci-owns-the-lockfile.md) — Why lockfile updates are centralized in automation instead of ordinary pull requests.
+
 ---
 
 ## Toolchain Versions

--- a/infrastructure/ci-cd/ci-owns-the-lockfile.md
+++ b/infrastructure/ci-cd/ci-owns-the-lockfile.md
@@ -1,0 +1,37 @@
+---
+title: "CI Owns The Lockfile"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# CI Owns The Lockfile
+
+In a pnpm workspace with frequent package changes, hand-edited lockfiles create
+merge churn and make it harder to tell whether dependency state is trustworthy.
+
+## Decision
+
+Treat `pnpm-lock.yaml` as CI-owned state. Regular pull requests are not allowed
+to edit it directly; the dedicated lockfile refresh workflow is the canonical
+path for lockfile updates.
+
+## Why
+
+This reduces noisy merge conflicts, keeps dependency refreshes explicit, and
+helps ensure that install reproducibility is enforced by automation rather than
+left to contributor discipline.
+
+## Implications
+
+- The PR policy workflow should keep rejecting manual lockfile edits except for
+  the designated refresh path.
+- Manifest changes may require or trigger an automated lockfile refresh PR.
+- Dependency debugging should distinguish between source changes and lockfile
+  state changes, since they are intentionally separated.
+- Docker and CI install behavior remain aligned around a single lockfile source
+  of truth.
+
+## Related Domains
+
+- [infrastructure deployment](../deployment/NODE.md)
+- [infrastructure testing](../testing/NODE.md)
+- [engineering](../../engineering/NODE.md)

--- a/infrastructure/deployment/NODE.md
+++ b/infrastructure/deployment/NODE.md
@@ -57,6 +57,10 @@ The untrusted-review container is designed for running AI agents on untrusted co
 
 CI builds `linux/amd64` and `linux/arm64` images. Uses Docker Buildx with GitHub Actions cache (`type=gha`). Published to GitHub Container Registry (`ghcr.io`).
 
+## Decision Records
+
+- [authenticated-docker-and-local-trusted-dev.md](authenticated-docker-and-local-trusted-dev.md) — Why Docker defaults to authenticated mode while local development keeps a trusted fast path.
+
 ---
 
 ## Environment Variables (Production Defaults)

--- a/infrastructure/deployment/authenticated-docker-and-local-trusted-dev.md
+++ b/infrastructure/deployment/authenticated-docker-and-local-trusted-dev.md
@@ -1,0 +1,38 @@
+---
+title: "Authenticated Docker And Local Trusted Dev"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Authenticated Docker And Local Trusted Dev
+
+Paperclip needs safe defaults in networked deployments without making local
+development and onboarding unnecessarily heavy.
+
+## Decision
+
+Use two load-bearing deployment modes: Docker and hosted-style environments
+default to `authenticated` mode with external Postgres, while local development
+and local e2e workflows use `local_trusted` mode with embedded database flows.
+
+## Why
+
+This preserves a low-friction developer loop while making authentication and
+clear environment boundaries the default for any deployment that is exposed
+beyond a single trusted local machine.
+
+## Implications
+
+- Auth, API access, and UI flows must always respect deployment mode instead of
+  assuming one universal runtime posture.
+- Compose and production entrypoints should fail fast when required auth
+  configuration is missing.
+- Local tests can stay simple and deterministic by relying on embedded storage
+  and trusted-mode shortcuts.
+- Feature work that behaves differently across trusted and authenticated modes
+  should make that distinction explicit in both code and docs.
+
+## Related Domains
+
+- [engineering backend](../../engineering/backend/NODE.md)
+- [product governance](../../product/governance/NODE.md)
+- [infrastructure testing](../testing/NODE.md)

--- a/infrastructure/testing/NODE.md
+++ b/infrastructure/testing/NODE.md
@@ -69,6 +69,10 @@ Both e2e and release-smoke workflows upload Playwright HTML reports and test res
 
 `scripts/check-forbidden-tokens.mjs` scans the codebase for tokens that should never be committed (API keys, secrets). Run via `pnpm check:tokens`. This is a guardrail against accidental secret commits.
 
+## Decision Records
+
+- [no-llm-calls-in-default-ci.md](no-llm-calls-in-default-ci.md) — Why standard CI avoids required live model-provider calls.
+
 ---
 
 ## Test Commands Reference

--- a/infrastructure/testing/no-llm-calls-in-default-ci.md
+++ b/infrastructure/testing/no-llm-calls-in-default-ci.md
@@ -1,0 +1,38 @@
+---
+title: "No LLM Calls In Default CI"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# No LLM Calls In Default CI
+
+Paperclip integrates with agent runtimes and model providers, but its default
+CI path should remain reliable even when providers are unavailable or costly.
+
+## Decision
+
+Keep standard CI and release verification free of required live LLM calls.
+Model-dependent checks belong in separate manual or specialized evaluation
+lanes, while default e2e and verify jobs use deterministic shortcuts and skip
+flags when needed.
+
+## Why
+
+This keeps CI fast, reproducible, and affordable while still preserving room
+for deeper runtime evaluation in dedicated workflows.
+
+## Implications
+
+- A normal pull request should not require provider credentials or incur model
+  spend just to prove the codebase is healthy.
+- E2E flows can run in trusted local mode with model-dependent assertions
+  disabled when necessary.
+- Prompt and runtime quality evaluation still matters, but it should be staged
+  separately from core correctness and release safety checks.
+- Failures in model-provider integrations should be investigated through the
+  eval lane or targeted smoke runs, not by making mainline CI flaky.
+
+## Related Domains
+
+- [infrastructure ci/cd](../ci-cd/NODE.md)
+- [product agent model](../../product/agent-model/NODE.md)
+- [adapters](../../adapters/NODE.md)

--- a/plugins/examples/NODE.md
+++ b/plugins/examples/NODE.md
@@ -24,6 +24,10 @@ Provide copy-able starting points for plugin authors and serve as living documen
 - **Examples live in-tree, not in a separate repo.** They are part of the pnpm workspace and import `@paperclipai/plugin-sdk` via `workspace:*`. This ensures they always compile against the current SDK version.
 - **Graduated complexity.** Hello World shows the minimum, File Browser shows a realistic integration, Kitchen Sink shows the full surface. Authors pick the closest starting point.
 
+## Decision Records
+
+- [examples-live-in-tree-as-sdk-contract-tests.md](examples-live-in-tree-as-sdk-contract-tests.md) — Why example plugins are kept in-workspace as both docs and compatibility coverage.
+
 ## Boundaries
 
 Examples demonstrate SDK usage patterns. They do not define the API surface (that is `../sdk`) or implement host-side behavior (that is `../runtime`).

--- a/plugins/examples/examples-live-in-tree-as-sdk-contract-tests.md
+++ b/plugins/examples/examples-live-in-tree-as-sdk-contract-tests.md
@@ -1,0 +1,36 @@
+---
+title: "Examples Live In-Tree As SDK Contract Tests"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Examples Live In-Tree As SDK Contract Tests
+
+Paperclip's example plugins are not just marketing samples. They are part of
+how the project proves the SDK stays usable.
+
+## Decision
+
+Keep example plugins inside the main workspace and treat them as both living
+documentation and lightweight contract tests for the plugin SDK.
+
+## Why
+
+When examples compile against the current workspace version, they provide
+copyable reference projects for authors while also exposing SDK breakage much
+earlier than a separate documentation repo would.
+
+## Implications
+
+- SDK changes should consider whether one or more examples need updating as
+  part of the same change.
+- Example coverage should expand when a major plugin surface is added so the
+  public contract has a concrete demonstration.
+- Examples are intentionally reference implementations, not production plugins
+  that define the runtime contract themselves.
+- Test and documentation value are both reasons to keep these examples close to
+  the SDK source.
+
+## Related Domains
+
+- [plugins sdk](../sdk/NODE.md)
+- [infrastructure testing](../../infrastructure/testing/NODE.md)

--- a/plugins/sdk/NODE.md
+++ b/plugins/sdk/NODE.md
@@ -31,6 +31,10 @@ Give third-party developers a clean, typed, versioned API for extending Papercli
 - **UI slot isolation.** Plugin UI bundles are loaded into named slots (dashboardWidget, detailTab, sidebar, projectSidebarItem, commentAnnotation, commentContextMenuItem, settingsPage, page). Props always include a `PluginHostContext` with current company/project/entity IDs.
 - **Zod re-exported.** The SDK re-exports Zod so plugin authors can define config schemas and tool parameter schemas without adding a separate dependency.
 
+## Decision Records
+
+- [single-sdk-dependency-and-zod-reexports.md](single-sdk-dependency-and-zod-reexports.md) — Why plugin authors target one SDK package instead of importing host internals directly.
+
 ## Boundaries
 
 The SDK defines the contract; it does not implement the host side. Host-side service implementations (worker manager, event bus, job scheduler) live in `../runtime`. Shared type definitions and constants originate in `../../engineering/shared` and are re-exported through this SDK.

--- a/plugins/sdk/single-sdk-dependency-and-zod-reexports.md
+++ b/plugins/sdk/single-sdk-dependency-and-zod-reexports.md
@@ -1,0 +1,39 @@
+---
+title: "Single SDK Dependency And Zod Re-Exports"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Single SDK Dependency And Zod Re-Exports
+
+Paperclip's plugin ecosystem is easier to adopt when authors do not need to
+understand the host's package graph in order to build an extension.
+
+## Decision
+
+Expose plugin authoring through a single public package,
+`@paperclipai/plugin-sdk`, and re-export the shared contract types plus Zod
+from that package instead of asking authors to import multiple internal
+packages directly.
+
+## Why
+
+This creates a narrow, stable public surface for plugin development and keeps
+host internals replaceable without turning every plugin into a tightly coupled
+workspace consumer.
+
+## Implications
+
+- New plugin-facing capabilities should be added to the SDK instead of telling
+  authors to reach into host-only packages.
+- Examples and scaffolding should compile against the SDK as the canonical
+  authoring surface.
+- Shared types can evolve behind the SDK boundary without requiring plugin
+  authors to track internal package topology.
+- Config schemas and tool parameter schemas can use Zod without forcing a
+  second dependency decision on every plugin author.
+
+## Related Domains
+
+- [plugins runtime](../runtime/NODE.md)
+- [plugins examples](../examples/NODE.md)
+- [engineering shared](../../engineering/shared/NODE.md)

--- a/product/agent-model/NODE.md
+++ b/product/agent-model/NODE.md
@@ -76,6 +76,10 @@ Paperclip ships default agent templates:
 
 These are starting points and reference implementations, not mandated patterns.
 
+## Decision Records
+
+- [adapter-defined-agent-internals.md](adapter-defined-agent-internals.md) — Why Paperclip owns control-plane agent fields while adapters own runtime-specific behavior.
+
 ## Agent Statuses
 
 `active`, `paused`, `idle`, `running`, `error`, `terminated`. Terminated is irreversible (board only).

--- a/product/agent-model/adapter-defined-agent-internals.md
+++ b/product/agent-model/adapter-defined-agent-internals.md
@@ -1,0 +1,40 @@
+---
+title: "Adapter-Defined Agent Internals"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Adapter-Defined Agent Internals
+
+Paperclip coordinates many agent runtimes, but it should not hard-code how each
+runtime defines its own prompts, files, or inner-loop behavior.
+
+## Decision
+
+Paperclip owns the control-plane fields for an agent, while runtime-specific
+identity and behavior details remain adapter-defined concerns. Files such as
+agent prompts, skills, and runtime config belong to the adapter layer rather
+than the core agent model.
+
+## Why
+
+This keeps the control plane vendor-agnostic and allows local CLIs, remote
+gateways, and future runtimes to participate without forcing one universal
+execution model onto all of them.
+
+## Implications
+
+- Adding a new runtime should usually extend adapter config and capability
+  surfaces, not the core `Agent` concept.
+- Paperclip does not need to understand the semantics of `CLAUDE.md`,
+  `SOUL.md`, heartbeat instructions, or provider-specific prompt files in order
+  to orchestrate the agent.
+- Product comparisons between runtimes should be expressed as adapter
+  capabilities and constraints, not as divergent core agent types.
+- Control-plane status, assignment, org structure, and governance remain
+  stable even when agent internals vary widely.
+
+## Related Domains
+
+- [adapters](../../adapters/NODE.md)
+- [product company model](../company-model/NODE.md)
+- [engineering backend](../../engineering/backend/NODE.md)

--- a/product/company-model/NODE.md
+++ b/product/company-model/NODE.md
@@ -45,6 +45,10 @@ V1 supports import/export using a portable package contract:
 
 **Rationale:** Exportable company configs enable sharing templates ("pre-built marketing agency"), version-controlling org structure, and duplicating/forking companies. The markdown-first approach keeps packages readable and vendor-neutral.
 
+## Decision Records
+
+- [company-is-the-top-level-boundary.md](company-is-the-top-level-boundary.md) — Why Company is the primary isolation, governance, and work boundary in Paperclip.
+
 ## Open Questions
 
 - Company-level settings and configuration surface (beyond what exists today)

--- a/product/company-model/company-is-the-top-level-boundary.md
+++ b/product/company-model/company-is-the-top-level-boundary.md
@@ -1,0 +1,38 @@
+---
+title: "Company Is The Top-Level Organizational Boundary"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Company Is The Top-Level Organizational Boundary
+
+Paperclip is built around the idea that an autonomous company is the primary
+unit of organization, not a team, workspace, or chat room.
+
+## Decision
+
+Treat the Company as the first-order boundary for data, governance, budgeting,
+and work organization. Every business entity belongs to exactly one company,
+while one deployment may host multiple companies for the same operator.
+
+## Why
+
+This matches the product's core metaphor, creates a natural isolation boundary,
+and avoids the extra trust and billing complexity that a multi-tenant SaaS
+model would introduce in V1.
+
+## Implications
+
+- Cross-company data access should be treated as an exception or bug, not a
+  routine workflow.
+- Budget rollups, approvals, org structure, tasks, and costs all anchor at the
+  company level before going deeper.
+- Import/export and portability features should preserve the company as the
+  stable package boundary.
+- Deployment-level multi-company support exists for one operator running
+  multiple businesses, not for unrelated operators sharing an instance.
+
+## Related Domains
+
+- [product governance](../governance/NODE.md)
+- [product agent model](../agent-model/NODE.md)
+- [engineering database](../../engineering/database/NODE.md)

--- a/product/task-system/NODE.md
+++ b/product/task-system/NODE.md
@@ -62,6 +62,10 @@ When an agent crashes mid-task, Paperclip does **not** auto-reassign or auto-rel
 
 Fixed, non-customizable: No priority (0), Urgent (1), High (2), Medium (3), Low (4). Intentionally small. Use labels for additional categorization.
 
+## Decision Records
+
+- [tasks-are-the-communication-channel.md](tasks-are-the-communication-channel.md) — Why Paperclip keeps agent coordination attached to tasks instead of introducing a separate chat layer.
+
 ## Open Questions
 
 - Team-specific workflow states (aspirational model from TASKS.md) -- when to implement beyond the V1 fixed enum

--- a/product/task-system/tasks-are-the-communication-channel.md
+++ b/product/task-system/tasks-are-the-communication-channel.md
@@ -1,0 +1,40 @@
+---
+title: "Tasks Are The Communication Channel"
+owners: [cryppadotta, serenakeyitan]
+---
+
+# Tasks Are The Communication Channel
+
+Paperclip is not designed around a separate agent chat layer. Coordination is
+supposed to happen where the work already lives.
+
+## Decision
+
+Use tasks, task assignment, comments, and task state changes as the canonical
+communication channel between agents and between agents and the board. Do not
+introduce a parallel chat or messaging system as a first-class coordination
+surface.
+
+## Why
+
+This keeps context attached to the work that generated it, makes auditability a
+natural property of the system, and gives humans a board-level view that is
+organized around progress and responsibility instead of fragmented
+conversations.
+
+## Implications
+
+- An agent's effective inbox is its assigned tasks plus relevant task comments.
+- New collaboration features should usually enrich the task system rather than
+  creating side channels that split context.
+- Escalation, delegation, blocking, and progress reporting should remain
+  visible on the work graph.
+- Cost attribution and governance review stay easier because the discussion is
+  attached to the same objects that drive execution.
+
+## Related Domains
+
+- [product agent model](../agent-model/NODE.md)
+- [product governance](../governance/NODE.md)
+- [engineering backend](../../engineering/backend/NODE.md)
+- [engineering frontend](../../engineering/frontend/NODE.md)


### PR DESCRIPTION
## Summary
- add a human-friendly root README for the Paperclip Context Tree
- add first-pass decision records across engineering, product, infrastructure, plugins, and selected adapters
- index the new records from their parent NODE.md files and refresh CODEOWNERS

## Verification
- npx -y -p first-tree first-tree verify --skip-version-check