### PR TITLE
Add reciprocal soft links across key domains

### DIFF
--- a/adapters/NODE.md
+++ b/adapters/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "Adapters"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["engineering/backend", "engineering/cli", "engineering/frontend"]
+soft_links: ["engineering/NODE.md", "engineering/backend", "engineering/cli", "engineering/frontend", "infrastructure/NODE.md", "product/NODE.md", "product/agent-model/NODE.md"]
 ---
 
 # Adapters

--- a/engineering/NODE.md
+++ b/engineering/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "Engineering"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["adapters", "plugins", "infrastructure"]
+soft_links: ["adapters", "plugins", "infrastructure", "infrastructure/deployment/NODE.md", "infrastructure/testing/NODE.md", "product/NODE.md", "product/agent-model/NODE.md", "product/company-model/NODE.md", "product/governance/NODE.md", "product/task-system/NODE.md"]
 ---
 
 # Engineering

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "Backend Server"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["engineering/database", "engineering/shared", "engineering/frontend", "adapters", "plugins"]
+soft_links: ["engineering/database", "engineering/shared", "engineering/frontend", "engineering/cli/NODE.md", "adapters", "adapters/claude-local/NODE.md", "adapters/codex-local/NODE.md", "adapters/cursor-local/NODE.md", "adapters/gemini-local/NODE.md", "adapters/openclaw-gateway/NODE.md", "adapters/opencode-local/NODE.md", "adapters/pi-local/NODE.md", "plugins", "plugins/runtime/NODE.md"]
 ---
 
 # Backend Server

--- a/engineering/cli/NODE.md
+++ b/engineering/cli/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["engineering/backend", "engineering/shared", "engineering/database"]
+soft_links: ["engineering/backend", "engineering/shared", "engineering/database", "adapters/NODE.md"]
 ---
 
 # CLI

--- a/engineering/database/NODE.md
+++ b/engineering/database/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "Database"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["engineering/backend", "engineering/shared"]
+soft_links: ["engineering/backend", "engineering/shared", "engineering/cli/NODE.md", "plugins/runtime/NODE.md"]
 ---
 
 # Database

--- a/engineering/shared/NODE.md
+++ b/engineering/shared/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "Shared Package"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["engineering/backend", "engineering/frontend", "engineering/cli", "engineering/database"]
+soft_links: ["engineering/backend", "engineering/frontend", "engineering/cli", "engineering/database", "plugins/sdk/NODE.md"]
 ---
 
 # Shared Package

--- a/plugins/NODE.md
+++ b/plugins/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "Plugins"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["engineering/backend"]
+soft_links: ["engineering/NODE.md", "engineering/backend", "product/NODE.md"]
 ---
 
 # Plugins

--- a/plugins/sdk/NODE.md
+++ b/plugins/sdk/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "Plugin SDK"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["plugins/runtime", "engineering/shared"]
+soft_links: ["plugins/runtime", "plugins/examples/NODE.md", "engineering/shared"]
 ---
 
 # Plugin SDK

--- a/product/agent-model/NODE.md
+++ b/product/agent-model/NODE.md
@@ -1,7 +1,7 @@
 ---
 title: "Agent Model"
 owners: [cryppadotta, serenakeyitan]
-soft_links: ["product/governance/NODE.md", "product/task-system/NODE.md", "adapters/NODE.md", "engineering/NODE.md"]
+soft_links: ["product/governance/NODE.md", "product/task-system/NODE.md", "product/company-model/NODE.md", "adapters/NODE.md", "engineering/NODE.md"]
 ---
 
 # Agent Model


### PR DESCRIPTION
## Summary
- add reciprocal soft_links for key engineering, product, adapter, plugin, and infrastructure relationships
- make domain navigation more bidirectional instead of relying on one-way references
- eliminate one-way soft_link infos from first-tree verification

## Verification
- npx -y -p first-tree first-tree verify --skip-version-check