### PR TITLE
sync(paperclip-e392f6b1): feat(issue-ui): refine issue workflow surfaces and live updates (from paperclipai/paperclip#3222)

### DIFF
--- a/.first-tree/bindings/paperclip-e392f6b1.json
+++ b/.first-tree/bindings/paperclip-e392f6b1.json
@@ -1,8 +1,8 @@
 {
   "bindingMode": "standalone-source",
   "entrypoint": "/",
-  "lastReconciledAt": "2026-04-13T12:28:17.874Z",
-  "lastReconciledSourceCommit": "d6b06788f6efacb002791c1a60b4889d7bfdb22d",
+  "lastReconciledAt": "2026-04-13T20:56:05.339Z",
+  "lastReconciledSourceCommit": "5d1ed71779df5622d9fd99ad28816b2da4bdee31",
   "remoteUrl": "https://github.com/paperclipai/paperclip",
   "rootKind": "git-repo",
   "schemaVersion": 2,

--- a/drift/paperclip-e392f6b1/engineering/NODE.md
+++ b/drift/paperclip-e392f6b1/engineering/NODE.md
@@ -1,0 +1,6 @@
+---
+title: "engineering"
+owners: []
+---
+
+Auto-generated intermediate node for sync proposals.

--- a/drift/paperclip-e392f6b1/engineering/frontend/NODE.md
+++ b/drift/paperclip-e392f6b1/engineering/frontend/NODE.md
@@ -1,0 +1,6 @@
+---
+title: "frontend"
+owners: []
+---
+
+Auto-generated intermediate node for sync proposals.

--- a/drift/paperclip-e392f6b1/engineering/frontend/issue-detail-ux/NODE.md
+++ b/drift/paperclip-e392f6b1/engineering/frontend/issue-detail-ux/NODE.md
@@ -1,0 +1,19 @@
+---
+title: "Issue Detail UX"
+owners: [@bingran-you, @serenakeyitan, @bingran-you, @serenakeyitan]
+---
+
+## Overview
+
+The issue detail view is the primary workspace where humans and agents collaborate on tasks. It follows a chat-like thread layout with structured panels for metadata, attachments, and sub-issues.
+
+## Key Decisions
+
+- **Inline sub-issues** — Sub-issues are displayed inline within the parent issue view rather than in a separate tab. This reduces navigation friction and keeps the full issue hierarchy visible in context. Sub-issues default to the parent's workspace.
+- **Image attachment gallery grid** — Image attachments render as square-cropped gallery grids rather than inline full-size images, keeping the thread scannable when agents attach screenshots or diagrams.
+- **Scroll-to-bottom button offset** — The scroll-to-bottom button offsets when the properties panel is open, preventing overlap with side panels.
+- **Inline document diff rendering** — Document diffs are rendered inline within the thread rather than in a separate view.
+
+## Inbox Customization
+
+The inbox grid supports show/hide columns including an optional Parent Issue column. Parent issue and time-ago columns use narrow widths to maximize space for issue content.

--- a/drift/paperclip-e392f6b1/engineering/frontend/issue-list-workflows/NODE.md
+++ b/drift/paperclip-e392f6b1/engineering/frontend/issue-list-workflows/NODE.md
@@ -1,0 +1,29 @@
+---
+title: "Issue List & Board Workflows"
+owners: [@bingran-you, @serenakeyitan, @bingran-you, @serenakeyitan]
+---
+
+# Issue List & Board Workflows
+
+The issue list is the primary surface for browsing, filtering, and acting on issues across a company's task hierarchy. It supports both board-style (kanban) and list-style views.
+
+## Key Patterns
+
+### Inline Workflow Transitions
+
+Users and agents can transition issue status, change assignees, and update priority directly from the list view without opening the detail page. This reduces friction for triage workflows where many issues need quick action.
+
+### Filtering and Grouping
+
+Issue lists support filtering by status, assignee, priority, team, and label. Grouping (e.g., by status column or by assignee) provides different lenses on the same data. These filters map directly to query parameters on the backend issues API.
+
+## Key Decisions
+
+- **List and board are views over the same data and API.** Switching between list and board does not change the underlying query — only the rendering.
+- **Filters are URL-driven.** Filter state is encoded in the URL so that views are shareable and bookmarkable.
+
+## Open Questions
+
+- Saved/named views — whether users can save filter+sort combinations as named views
+- Bulk actions — selecting multiple issues for batch status/assignee changes
+- Default sort order and how it differs between agent-facing and human-facing contexts

--- a/drift/paperclip-e392f6b1/engineering/frontend/live-updates/NODE.md
+++ b/drift/paperclip-e392f6b1/engineering/frontend/live-updates/NODE.md
@@ -1,0 +1,25 @@
+---
+title: "Live Updates"
+owners: [@bingran-you, @serenakeyitan, @bingran-you, @serenakeyitan]
+---
+
+## Live Updates
+
+Real-time update pattern used across the Paperclip frontend to keep issue workflow surfaces current without manual refresh.
+
+### Key Decisions
+
+#### Live Update Mechanism
+
+The frontend uses a live update strategy to reflect issue state changes (status transitions, new comments, assignment changes) in near-real-time. This was introduced as part of the issue workflow refinement (PR #3222) to ensure that board views, detail panels, and inbox surfaces stay synchronized with backend state.
+
+**Rationale:** Autonomous agents move fast — an issue can transition through multiple states in seconds. Stale UI creates confusion for human board operators who need accurate visibility to exercise governance. Live updates close the gap between agent activity and human awareness.
+
+### Integration with React Query
+
+Live updates integrate with the existing React Query cache invalidation model rather than introducing a separate state synchronization layer. This keeps the "no global state library" principle intact while adding reactivity.
+
+### Open Questions
+
+- Specific transport mechanism (SSE vs WebSocket vs polling) and its configuration
+- Backpressure and throttling strategy for high-activity companies with many concurrent agents

--- a/drift/paperclip-e392f6b1/product/task-system/inbox-workflows/NODE.md
+++ b/drift/paperclip-e392f6b1/product/task-system/inbox-workflows/NODE.md
@@ -1,0 +1,26 @@
+---
+title: "Inbox Workflows"
+owners: [@bingran-you, @serenakeyitan, @bingran-you, @serenakeyitan, @bingran-you, @serenakeyitan, @bingran-you, @serenakeyitan]
+---
+
+# Inbox Workflows
+
+The inbox is the primary entry point for agents and humans to see what needs their attention. It aggregates tasks assigned to them, comments on tasks they're involved in, and status changes on watched items.
+
+## Key Decisions
+
+### Inbox as a Workflow Surface
+
+The inbox is not just a notification list — it is an actionable workflow surface. Users and agents can triage, filter, and act on items directly from the inbox without navigating to individual issue detail views. This reduces context-switching for agents processing multiple tasks.
+
+**Rationale:** Agents operating autonomously need to efficiently process their work queue. A passive notification list forces round-trips to detail views for every action. An actionable inbox keeps the agent's decision loop tight.
+
+### Issue List Integration
+
+The issue list and inbox share filtering and display patterns but serve different purposes: the issue list is a team-scoped view of all work, while the inbox is a personal view of items requiring the viewer's attention. Their interaction patterns are aligned so users build one mental model for navigating work items.
+
+## Open Questions
+
+- Inbox prioritization logic — how items are ranked (recency vs. urgency vs. blocking status)
+- Read/unread state tracking for inbox items
+- Agent-specific inbox behaviors vs. human inbox behaviors


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: db4e146..5d1ed71
- Proposal files: 4

Proposals:
- TREE_MISS: engineering/frontend/live-updates — The frontend node documents React Query for server state but has no node covering real-time/live update patterns (SSE, WebSocket, polling, or optimistic update strategies) introduced in this PR.
- TREE_MISS: engineering/frontend/issue-detail-ux — PR #3222 introduces significant issue detail UX patterns — inline sub-issues, image attachment gallery grids, scroll-to-bottom offsets, and inline document diff rendering — none of which are captured in the frontend node.
- TREE_MISS: engineering/frontend/issue-list-workflows — The tree has no node documenting how issue lists are filtered, sorted, grouped, or how inline workflow transitions (status changes, assignment) are performed from the list and board views.
- TREE_MISS: product/task-system/inbox-workflows — The task system node defines inbox conceptually ('tasks assigned + comments') but has no node capturing inbox UX workflow decisions — how work items are surfaced, filtered, sorted, and acted upon as an actionable workflow surface.

Commits:
- [`bf3fba3`](https://github.com/paperclipai/paperclip/commit/bf3fba36f2fcb2bc3e5126c42ad9ab49b22cbf4e) Offset scroll-to-bottom button when properties panel is open
- [`1b55474`](https://github.com/paperclipai/paperclip/commit/1b55474a9b7f7daf3ce168a1932b383af4e6aff6) Display image attachments as square-cropped gallery grid
- [`c414790`](https://github.com/paperclipai/paperclip/commit/c41479040459df6e97124a0491776cd181966431) Move sub-issues inline and remove sub-issues tab
- [`b3b9d99`](https://github.com/paperclipai/paperclip/commit/b3b9d99519b6427f795329df8582679041714f65) Add optional Parent Issue column to inbox show/hide columns
- [`0edac73`](https://github.com/paperclipai/paperclip/commit/0edac73a683a847443249db4550a3ef274c7bc2d) Narrow parent issue and time-ago columns in inbox grid
- [`5136381`](https://github.com/paperclipai/paperclip/commit/5136381d8f3521959b918d823b417a8871fa66e3) Speed up issue search
- [`4b654fc`](https://github.com/paperclipai/paperclip/commit/4b654fc81ed46495ef0880ed590206599ddcc784) fix(ui): restore attachment delete state hook order
- [`f1bb175`](https://github.com/paperclipai/paperclip/commit/f1bb175584c933934051cb615fd03f16311eb00b) feat(mcp): add approval creation tool
- [`492e49e`](https://github.com/paperclipai/paperclip/commit/492e49e1c0b3e1513f4ed150187df86dee7e62d5) test(cli): cover project env in import preview fixtures
- [`d71ff90`](https://github.com/paperclipai/paperclip/commit/d71ff903e45379954c6fe33566d4b6e7da57e8ae) test(cli): keep import preview fixtures aligned with manifest shape
- [`622a8e4`](https://github.com/paperclipai/paperclip/commit/622a8e44bfccd53cc384e4ff7a7ca2684573644d) refactor(ui): inline document diff rendering
- [`85ca675`](https://github.com/paperclipai/paperclip/commit/85ca6753113d8be175fa26de06534e7eb668c785) fix(docker): include mcp server manifest in deps stage
- [`a3ecc08`](https://github.com/paperclipai/paperclip/commit/a3ecc086d97e5750cbf56638d67fa4f5dc89ef2c) test(ui): wait for async issue search results
- [`9a150ee`](https://github.com/paperclipai/paperclip/commit/9a150eee657c17ea3d214154ef01e6e6657b6d3f) fix(ui): remove runtime-only preflight hook dependency
- [`669e5c8`](https://github.com/paperclipai/paperclip/commit/669e5c87cc69c1dc4c4c30feb861628702cc5917) fix(mcp): tighten api request validation
- [`1de1393`](https://github.com/paperclipai/paperclip/commit/1de139341353328ab92936b639e3a76fbf16efe6) fix(runtime): handle empty dev runner responses
- [`51414be`](https://github.com/paperclipai/paperclip/commit/51414be269b67d6da58d98c67aaf8c63f7c8e87e) fix(ui): address review follow-ups
- [`2c8cb7f`](https://github.com/paperclipai/paperclip/commit/2c8cb7f519b9c876d881607586fa9c7853d5237e) fix(ci): support manifest changes without lockfile
- [`ac47382`](https://github.com/paperclipai/paperclip/commit/ac473820a38a27de3a7560b3cf52a156478e7f4a) fix(ci): drop lockfile changes from mcp pr
- [`1e4d252`](https://github.com/paperclipai/paperclip/commit/1e4d252661f8acaa6dcb22a97f90c2edc9f35b3c) fix(ci): restore lockfile to pr base
- [`bb980bf`](https://github.com/paperclipai/paperclip/commit/bb980bfb335aea2b6b470a4a89d5844782140d94) fix(ci): fetch base sha in pr jobs
- [`3e0ab97`](https://github.com/paperclipai/paperclip/commit/3e0ab97b12fa389354db37ad52aa92b9686e5058) Merge pull request #2951 from Lempkey/fix/company-prefix-export-import-links
- [`e2962e6`](https://github.com/paperclipai/paperclip/commit/e2962e6528a11b19266cd121e6f5faac378080dc) fix: increase Node keepAliveTimeout behind reverse proxies to prevent 502s
- [`48704c6`](https://github.com/paperclipai/paperclip/commit/48704c658668ce45dcf092bf12761f99c019360d) fix(export): strip project env values from company packages
- [`448e9f2`](https://github.com/paperclipai/paperclip/commit/448e9f2be3a603785aefaf7341d3d0bbcea32d24) revert(ci): drop pr workflow changes from mcp pr
- [`f3e5c55`](https://github.com/paperclipai/paperclip/commit/f3e5c55f45f749a6e77b68f026a05bf7487ac362) test(cli): align env input fixtures with project scope
- [`502d60b`](https://github.com/paperclipai/paperclip/commit/502d60b2a89ae91d9e79aa01c6cd00e8b7814800) Merge pull request #2999 from paperclipai/pap-1167-runtime-worktree-hardening
- [`2c2e13e`](https://github.com/paperclipai/paperclip/commit/2c2e13eac22a0429f6202c293b7cf50cfe942e08) merge master into pap-1167-app-ui-bundle
- [`cae7cda`](https://github.com/paperclipai/paperclip/commit/cae7cda46325cee86e405ac312e17bee45edd921) Merge pull request #3000 from paperclipai/pap-1167-app-ui-bundle
- [`74481b1`](https://github.com/paperclipai/paperclip/commit/74481b1d1e68145215f4d9f2bf48d9d077848ffd) fix(ci): restore pr workflow from master
- [`2329a33`](https://github.com/paperclipai/paperclip/commit/2329a33f327c718701ea269086a583fee4984296) Merge remote-tracking branch 'public-gh/master' into pap-1167-mcp-server-package
- [`45f18d1`](https://github.com/paperclipai/paperclip/commit/45f18d1beefb93f8383ef5e3feeab2e68e0a8a09) Merge pull request #3001 from paperclipai/pap-1167-mcp-server-package
- [`aec88f1`](https://github.com/paperclipai/paperclip/commit/aec88f10ddcd86ede4163d24e4d7605d691d5651) Merge pull request #2909 from marysomething99-prog/fix/KAB-158-codex-missing-rollout
- [`07987d7`](https://github.com/paperclipai/paperclip/commit/07987d75adf8b6c49feb64d446e0b3f959886dd2) feat(claude-local): add Bedrock model selection support
- [`1c1d006`](https://github.com/paperclipai/paperclip/commit/1c1d006c5e20bd0d98fea387463327dcea13bf8c) chore: sync pnpm-lock.yaml with mcp-server package
- [`3a0e71b`](https://github.com/paperclipai/paperclip/commit/3a0e71b080d8950a38426899e2423b4615593f08) Revert "chore: sync pnpm-lock.yaml with mcp-server package"
- [`60744d8`](https://github.com/paperclipai/paperclip/commit/60744d8a917d6f4b69dad846850b617f0e17f00f) fix: address Greptile P2 — reuse DIRECT_MODELS import, global region prefix match
- [`26ebe3b`](https://github.com/paperclipai/paperclip/commit/26ebe3b002045b3064a22ecf9a4adc5670e4233f) Merge pull request #2662 from wbelt/fix/configurable-claimed-api-key-path
- [`ebd45b6`](https://github.com/paperclipai/paperclip/commit/ebd45b62cdc9a30124ab5946f20feec88f64437e) Provision local node_modules in issue worktrees
- [`53ffa50`](https://github.com/paperclipai/paperclip/commit/53ffa506386f1a6bd54ce15e9b4906d4c18bf4b7) Clean up opencode rebase and stabilize runtime test
- [`b6fe9eb`](https://github.com/paperclipai/paperclip/commit/b6fe9ebcbc651b4aa8bd32cef1cb2848ea351860) fix(ci): scope lockfile PR lookup to repo owner
- [`aa18aeb`](https://github.com/paperclipai/paperclip/commit/aa18aeb1e934ad0da38d4cccf43ced73790ac546) Merge pull request #3062 from paperclipai/pap-1177-refresh-lockfile-pr
- [`7e78ce0`](https://github.com/paperclipai/paperclip/commit/7e78ce0d7ebe9a8ffcd8a89b8a086cb4ffb43503) Merge pull request #2818 from mvanhorn/fix/2705-identifier-collision
- [`700b41f`](https://github.com/paperclipai/paperclip/commit/700b41f7e1985fee62fb411ba20d4975b6317523) Merge pull request #2819 from mvanhorn/fix/2753-bump-multer-cve
- [`8b7dafd`](https://github.com/paperclipai/paperclip/commit/8b7dafd218a26a6474b80bc07c817c332724f2c3) Merge pull request #2435 from paperclipai/PAP-874-chat-speed-issues
- [`47b025c`](https://github.com/paperclipai/paperclip/commit/47b025c146a9116e4d1c5ffdd6f382490e38a61a) Merge pull request #3009 from KhairulA/fix/keepalive-timeout
- [`391afa6`](https://github.com/paperclipai/paperclip/commit/391afa627f4f9bab3dfdcfb580d5707448c8f3d3) Merge pull request #2143 from shoaib050326/codex/issue-2131-openclaw-session-key
- [`93c7493`](https://github.com/paperclipai/paperclip/commit/93c74930543432a44a688d11a93c82f7caf65e10) Merge pull request #2936 from Lempkey/fix/express5-auth-wildcard-syntax
- [`6e894f2`](https://github.com/paperclipai/paperclip/commit/6e894f27a2565f0814903e5956208644fc9ba6b9) Merge pull request #2397 from HearthCore/fix/win11-opencode-cmd-shell
- [`3cd9a54`](https://github.com/paperclipai/paperclip/commit/3cd9a54d941da287b6f21a87e2315825eff6c07a) Merge pull request #2937 from Lempkey/fix/logger-respect-tz-env
- [`e10baee`](https://github.com/paperclipai/paperclip/commit/e10baee84cabf6375924f7c75860864e18595798) chore(lockfile): refresh pnpm-lock.yaml
- [`4b39b0c`](https://github.com/paperclipai/paperclip/commit/4b39b0cc14720de4d9711f6d9623818d98c64de9) Merge pull request #3063 from paperclipai/chore/refresh-lockfile
- [`b3e0c31`](https://github.com/paperclipai/paperclip/commit/b3e0c3123950549e725e402ea497c22bff95c17a) Add issue review policy and comment retry
- [`2e31fb7`](https://github.com/paperclipai/paperclip/commit/2e31fb7c91c8d721827b148378ea4ecb6af670cd) Add comprehensive e2e tests for signoff execution policy
- [`be51852`](https://github.com/paperclipai/paperclip/commit/be518529b7cea6d62fbded82a4f034f77fc1c814) Move reviewer/approver pickers to inline header pills
- [`cb6e615`](https://github.com/paperclipai/paperclip/commit/cb6e6151861e3676ef5a3842ba888a5959779222) Revert reviewer/approver pickers to sidebar, add to new-issue chip bar
- [`71d93c7`](https://github.com/paperclipai/paperclip/commit/71d93c79a51cc5ffdf71e810e980c626231ed6f2) Fix Upload button chip styling in new-issue dialog
- [`e7fe02c`](https://github.com/paperclipai/paperclip/commit/e7fe02c02fa10ee217fe503f4fec1e41d90e52e9) Move reviewer/approver to rows under assignee with three-dot menu
- [`ff333d6`](https://github.com/paperclipai/paperclip/commit/ff333d68287a419cc6ea9cccf71dae31c1a3d9bd) Align assignee/reviewer/approver pills vertically in new-issue dialog
- [`0a5ac9a`](https://github.com/paperclipai/paperclip/commit/0a5ac9affd69277a7faf84b9e693627ff11dac86) Clarify execution-policy reviewer guidance
- [`0e80e60`](https://github.com/paperclipai/paperclip/commit/0e80e606653ab17ae0dc9eb8e33e06b361ce8145) Document execution policy workflows
- [`25d3081`](https://github.com/paperclipai/paperclip/commit/25d308186da36855c1e403b702f7a034b755041b) Generate execution policy migration
- [`a0333f3`](https://github.com/paperclipai/paperclip/commit/a0333f3e9d27823cf0bc6bdb4d434b8a4ce9d469) Stabilize heartbeat comment batching assertion
- [`bce58d3`](https://github.com/paperclipai/paperclip/commit/bce58d353d62547d03df06628f059f3daf5e001b) fix execution policy decision persistence
- [`cb705c9`](https://github.com/paperclipai/paperclip/commit/cb705c9856d89a8cece64cc4c90beac527a98736) Fix signoff PR follow-up tests
- [`b0b85e6`](https://github.com/paperclipai/paperclip/commit/b0b85e6ba3e34d6783aa4644c347d315c3a2024d) Stabilize onboarding e2e cleanup paths
- [`a13ac0d`](https://github.com/paperclipai/paperclip/commit/a13ac0d56fcba4aa8a463a4eabe01794f4b7fd88) Merge pull request #3039 from paperclipai/PAP-1139-consider-a-signoff-required-execution-policy
- [`5ae335c`](https://github.com/paperclipai/paperclip/commit/5ae335c42f793ba652328a50aeb76a45ba3bcdac) Merge pull request #2148 from shoaib050326/codex/issue-2110-goal-show-properties
- [`f559455`](https://github.com/paperclipai/paperclip/commit/f559455d920b55e3b131e6a4a449c121e54a2cd2) Merge pull request #2512 from AllenHyang/fix/inbox-badge-counts-all-mine-issues-not-unread
- [`50a36be`](https://github.com/paperclipai/paperclip/commit/50a36beec553a11954a0bc751c59ae6d01efce08) Merge pull request #3033 from kimnamu/feat/bedrock-model-selection
- [`f55a5e5`](https://github.com/paperclipai/paperclip/commit/f55a5e557da4950a90c6a2513b677222c50ff683) Merge pull request #2866 from ergonaworks/fix/agent-auth-jwt-better-auth-secret-fallback
- [`54f93c1`](https://github.com/paperclipai/paperclip/commit/54f93c1f270c05c9531809980b2b714129e8080f) Merge pull request #2441 from DanielSousa/skill-removal-ui
- [`f2a2049`](https://github.com/paperclipai/paperclip/commit/f2a2049d17351d6782956ce5f1d92616b75027f8) Merge pull request #2442 from sparkeros/fix/capabilities-field-blank-screen
- [`943b851`](https://github.com/paperclipai/paperclip/commit/943b851a5ed84bfd0b783244392b297431405559) Merge pull request #2643 from chrisschwer/fix/stale-execution-lock-lifecycle
- [`9cfa37f`](https://github.com/paperclipai/paperclip/commit/9cfa37fce3c25988917b0631147413d171bf4e32) Merge pull request #1961 from antonio-mello-ai/fix/webhook-github-sentry-signing-modes
- [`73abe4c`](https://github.com/paperclipai/paperclip/commit/73abe4c76ef7954ed9c3b7f441ca8515acfdb70b) Implement assistant-ui issue chat thread
- [`3fea60c`](https://github.com/paperclipai/paperclip/commit/3fea60c04c49fb3a700f17da76bc8b0b10ffc208) Polish issue chat layout and add UX lab
- [`f593e11`](https://github.com/paperclipai/paperclip/commit/f593e116c1d272dc71b6f743cc3d900b87c1237a) Refine issue chat activity and message chrome
- [`8ada49f`](https://github.com/paperclipai/paperclip/commit/8ada49f31b92190ccf8bb8fd613cf53787696075) Polish issue chat actions and overflow
- [`4a75d05`](https://github.com/paperclipai/paperclip/commit/4a75d05969712a747a729d58cc9b969ae76d5133) Remove border and padding from chat thread outer container
- [`f741067`](https://github.com/paperclipai/paperclip/commit/f7410673fe567e437660e91652ee58813d68a4dc) Fix needs-work feedback panel closing immediately
- [`9131cc0`](https://github.com/paperclipai/paperclip/commit/9131cc03551d6b63e06e7dff23bb243b2f476152) Restyle issue chat comments for chat-like UX
- [`94652c6`](https://github.com/paperclipai/paperclip/commit/94652c6079ec5b73778bd510d02ec5c1684ac090) Fix chat comment alignment, avatars, and layout polish
- [`f94fe57`](https://github.com/paperclipai/paperclip/commit/f94fe57d10227a400fddb60a994846abeba04b34) Polish issue chat actions and overflow
- [`3574a3b`](https://github.com/paperclipai/paperclip/commit/3574a3bf498d60a61684b98bc7936716862ea7ef) Move user avatar outside content column to right margin
- [`d8a7342`](https://github.com/paperclipai/paperclip/commit/d8a734268670c40d1f6a20d49baff6ebe866e4dd) Fix avatar positioning and activity line alignment in chat
- [`2a372fb`](https://github.com/paperclipai/paperclip/commit/2a372fbe8a5394835d5150307f849a2d0762a04d) Refine issue chat chain-of-thought mapping
- [`627fbc8`](https://github.com/paperclipai/paperclip/commit/627fbc80ac248346d8eea66d4c483071341a8094) Polish issue chat chain-of-thought rendering
- [`2951460`](https://github.com/paperclipai/paperclip/commit/29514606bb0b1529a1b8ea70ac4f905157a8fd41) Refactor user message avatar to flex layout
- [`a57f6f4`](https://github.com/paperclipai/paperclip/commit/a57f6f48b427922d1719a69ac4534a045f2c7021) Move date/menu to action bar and fix activity label sizing
- [`e09dfb1`](https://github.com/paperclipai/paperclip/commit/e09dfb1a2cbea39b8eaff8b78b0993a58f0a80bc) Reorder action bar icons and add relative date formatting
- [`7dd3661`](https://github.com/paperclipai/paperclip/commit/7dd3661467c7fdee9a904d36fb181c96c0ad1411) Tweak issue chat run action
- [`34589ad`](https://github.com/paperclipai/paperclip/commit/34589ad457cddfe31fe33553d197dbec73edce63) Add worktree reseed command
- [`92f142f`](https://github.com/paperclipai/paperclip/commit/92f142f7f8e7b895cb1ae7492a7b1cc99e047c94) Polish issue chat transcript presentation
- [`fe96a2f`](https://github.com/paperclipai/paperclip/commit/fe96a2f97642da95fef240a7c9666646418ff631) Fix rebased issue detail chat props
- [`81b96c6`](https://github.com/paperclipai/paperclip/commit/81b96c6021a85e70aee78c895590fd04c11540ea) Update transcript message expectations
- [`b5e177d`](https://github.com/paperclipai/paperclip/commit/b5e177df7e9fb3cedda73d98f80ae2b2fb91382b) Address greptile review feedback
- [`950ea06`](https://github.com/paperclipai/paperclip/commit/950ea065ae72488aee31943c1dc00b3b5a5fd53f) Reuse chat-style run feed on dashboard
- [`667d5a7`](https://github.com/paperclipai/paperclip/commit/667d5a73846692eb64ad21c94d41fcf284d21005) Merge pull request #3079 from paperclipai/PAP-1132-assistant-ui-pap-1131-make-issues-comments-be-like-a-chat
- [`3cfbc35`](https://github.com/paperclipai/paperclip/commit/3cfbc350a04da9e8914ea934f4713e8a3c2c0326) fix: skip --append-system-prompt-file on resumed claude sessions
- [`e3804f7`](https://github.com/paperclipai/paperclip/commit/e3804f792dcb7b03c3d3edaebe2ae2da417b1396) fix: gate instructions file I/O and commandNotes on fresh sessions only
- [`fa3cbc7`](https://github.com/paperclipai/paperclip/commit/fa3cbc7fdb651922a7d5b75647c32ca6b530885e) chore: trigger Greptile re-review
- [`0ff262c`](https://github.com/paperclipai/paperclip/commit/0ff262ca0f30ec225e9c0da57b0ab51964cbe7b8) fix: preserve claude instructions on resume fallback
- [`8367c5f`](https://github.com/paperclipai/paperclip/commit/8367c5f406b3b835b9b09164fe4c8ccff44acc4d) Merge pull request #2949 from Lempkey/fix/skip-system-prompt-on-resume
- [`316790e`](https://github.com/paperclipai/paperclip/commit/316790ea0a223f034ad69294b8733a06917939e9) chore(lockfile): refresh pnpm-lock.yaml (#3109)
- [`cc44d30`](https://github.com/paperclipai/paperclip/commit/cc44d309c0a5f5bbc6d718d901f6e9ab27bae34d) feat(backups): gzip compress backups and add retention config to Instance Settings
- [`fcbae62`](https://github.com/paperclipai/paperclip/commit/fcbae62baf1e821e2b65f64545381defccda3230) feat(backups): tiered daily/weekly/monthly retention with UI controls
- [`b1e4573`](https://github.com/paperclipai/paperclip/commit/b1e457365b5ab2df0721b58417df2c70ef3e1168) fix: clean up orphaned .sql on compression failure and fix stale startup log
- [`b7a7dac`](https://github.com/paperclipai/paperclip/commit/b7a7dacfa309223601f0b10b176721232d903c9f) fix: remove hardcoded JWT secret fallback from createBetterAuthInstance
- [`642188f`](https://github.com/paperclipai/paperclip/commit/642188f90068e9e7fd2ca9e4d5a2eb1836b17898) Merge pull request #3124 from cleanunicorn/fix/better-auth-jwt-secret
- [`3264f9c`](https://github.com/paperclipai/paperclip/commit/3264f9c1f6f0ca6049ed8192a0862fc30e723b20) Fix typing lag in long comment threads (PAPA-63) (#3163)
- [`9f9a8cf`](https://github.com/paperclipai/paperclip/commit/9f9a8cfa2576ce819395705b17d450ecf903c5ad) skills: add prcheckloop CI remediation loop
- [`46892de`](https://github.com/paperclipai/paperclip/commit/46892ded18cda3fc4aa0edd7f5c0fd2111bd768c) Add worktree reseed command
- [`735c591`](https://github.com/paperclipai/paperclip/commit/735c591bad69246403a41d4bf750fb4bd902853d) docs: add manual mcp-server publish steps
- [`87db949`](https://github.com/paperclipai/paperclip/commit/87db949d3f01e4bcb1dec5d0adae343f8338de18) docs: survey pi and pi-mono hook surfaces
- [`56ee63b`](https://github.com/paperclipai/paperclip/commit/56ee63bfd04633dc072245c67609d82572589955) docs: add issue detail speed inventory plan
- [`4bd6247`](https://github.com/paperclipai/paperclip/commit/4bd62471f76aa4bc8eb34bfdde7579112fc53dd1) kill chrome test servers too
- [`4e20279`](https://github.com/paperclipai/paperclip/commit/4e2027930529fe3f095396e3c81a6bb310f7abe9) fix(skill): add scoped-wake fast path to skip full heartbeat on comment wakes
- [`d00860b`](https://github.com/paperclipai/paperclip/commit/d00860b12ae70b6f91389c3e5e0081f3b73f400c) Add in-progress issue recovery plan
- [`0937f07`](https://github.com/paperclipai/paperclip/commit/0937f07c7916e1d795e8d3d5c73b82f8a117e6bb) Remove standalone issue recovery plan doc
- [`482dac7`](https://github.com/paperclipai/paperclip/commit/482dac7097893fb5da78455895f24eb568361b48) docs: add agent-os technical report
- [`5758aba`](https://github.com/paperclipai/paperclip/commit/5758aba91e4c1b9b995400d7b7af0578d34f0237) docs: add agent-os follow-up plan
- [`0d27065`](https://github.com/paperclipai/paperclip/commit/0d270655ab7b9b2182ec1263d65411f5d5e475cb) Clarify repo plan docs vs issue plan documents
- [`b1e9215`](https://github.com/paperclipai/paperclip/commit/b1e9215375f79380ebb1879c80f757f8c6bb2241) docs: add browser process cleanup plan
- [`8e88577`](https://github.com/paperclipai/paperclip/commit/8e885773713265af2d3f6eb70a6c95a71c52b313) chore(dev): preflight workspace links and simplify worktree helpers
- [`372421e`](https://github.com/paperclipai/paperclip/commit/372421ef0b43db24340c9b64623324a36d7259f0) Add generic issue-linked board approvals
- [`1de5fb9`](https://github.com/paperclipai/paperclip/commit/1de5fb9316d2ad2b33c23bd5a0022a502e54ae47) Support routine variables in titles
- [`5640d29`](https://github.com/paperclipai/paperclip/commit/5640d29ab0b42851b17d54bd77725ef52c1340bc) Persist non-issue inbox dismissals
- [`844b061`](https://github.com/paperclipai/paperclip/commit/844b0612671c1c6384aeed9a321e35f3b738e30d) Disable timer heartbeats by default for new agents
- [`9eaf72a`](https://github.com/paperclipai/paperclip/commit/9eaf72ab3177017d22264752a2f4feea117ec9fb) Fix Codex tool-use transcript completion
- [`ec75cab`](https://github.com/paperclipai/paperclip/commit/ec75cabcd81d6ab5ddb809e26705218383d775c6) Enforce execution-policy stage handoffs
- [`8894520`](https://github.com/paperclipai/paperclip/commit/8894520ed0fa47f103a5d5cc3dbd3b541795cf4a) comment wake batching test
- [`3baebee`](https://github.com/paperclipai/paperclip/commit/3baebee2dfd3335631342a8a1a20a4a843eb1ca5) Track blocker and review activity events
- [`26d4cab`](https://github.com/paperclipai/paperclip/commit/26d4cabb2e8a041f15fb1080f421c35777128c21) Persist heartbeat child pid before stdin handoff
- [`27ec1e0`](https://github.com/paperclipai/paperclip/commit/27ec1e0c8b13cd881b6a4c794f17b37b56f1ebda) Fix execution policy edits on in-review issues
- [`c6779b5`](https://github.com/paperclipai/paperclip/commit/c6779b570f44079a80a360f3c6d6255a92fb55e0) feat(ui): add workspace and parent issue grouping to issues list
- [`93355ba`](https://github.com/paperclipai/paperclip/commit/93355bae6b08e9c005eddace77ca0d04815b1332) Debounce issues search input
- [`1cbb0a5`](https://github.com/paperclipai/paperclip/commit/1cbb0a5e34e801aa8576cc5ab5e110d43c1d7a0d) Add execution workspace issues tab
- [`ee82a4f`](https://github.com/paperclipai/paperclip/commit/ee82a4f2432ec865b3ad6648b8a3e898e91a5db6) Reuse inbox issue column controls in issues lists
- [`30dd2b7`](https://github.com/paperclipai/paperclip/commit/30dd2b78e5779c0fcabdf4c20572c3504d48dd80) Polish shared issue columns trigger styling
- [`db1279d`](https://github.com/paperclipai/paperclip/commit/db1279dc129278aab06ebaf6b1c7dcd2c0a0a51a) Make worktree banner name clickable to copy to clipboard
- [`bac5afa`](https://github.com/paperclipai/paperclip/commit/bac5afa6470e411a711cd6722aa5fcadc04e419d) Remove "None" text from empty Blocking and Sub-issues property rows
- [`038dd2b`](https://github.com/paperclipai/paperclip/commit/038dd2bb82dad47f77fec33b176ea284a9d62aec) Improve issue assignee update responsiveness
- [`1e4ccb2`](https://github.com/paperclipai/paperclip/commit/1e4ccb2b1fc04f25da8960122bf583ded6f7065d) Improve mobile comment copy button feedback
- [`1851952`](https://github.com/paperclipai/paperclip/commit/185195201a51f7792b5f51be2a4b2a24702ebb32) Adjust execution workspace header layout
- [`f5a87ab`](https://github.com/paperclipai/paperclip/commit/f5a87ab14ebb3bc15e3ed677807bce3dc96b1229) fix(ui): avoid issue detail ref update loops
- [`9159b44`](https://github.com/paperclipai/paperclip/commit/9159b44fcc03ac744d9c9fdd774691ee7058fc6d) fix(ui): update inbox badge test inputs
- [`2ec2b1f`](https://github.com/paperclipai/paperclip/commit/2ec2b1f1ebba1e2282ce628465e11e5b8e9a9da7) fix(ui): improve shimmer gradient and add Working/Worked tokens to Chat UX Lab
- [`c830c64`](https://github.com/paperclipai/paperclip/commit/c830c647276b5d57006a6bbec2759add1a88aec9) fix(ui): fix shimmer text using invalid hsl() wrapper on oklch colors
- [`d0920da`](https://github.com/paperclipai/paperclip/commit/d0920da4596eabc1e458873e01d15103856f90b3) feat(ui): open gallery when clicking images in chat messages
- [`f75c0c3`](https://github.com/paperclipai/paperclip/commit/f75c0c317cf2207b7e060ca0e8551dd91b6e418d) fix(ui): move useCallback hook before early returns in IssueDetail
- [`1a82646`](https://github.com/paperclipai/paperclip/commit/1a82646e9db33ad25ed03b2b6260908a9b8e8bc7) fix(ui): fix shimmer animation loop jitter by keeping gradient in view
- [`7edd2f7`](https://github.com/paperclipai/paperclip/commit/7edd2f79469929dcd02b44cfd73eef5694e7ee89) fix(ui): add pause between shimmer animation repeats
- [`28a28d1`](https://github.com/paperclipai/paperclip/commit/28a28d1cb6505542f2745613c0e4fd770941860d) fix(ui): eliminate flash when auto-folding work sections on page load
- [`c5ccafb`](https://github.com/paperclipai/paperclip/commit/c5ccafbb8018f0c1dc0a3fa74d9cad7d95489606) fix(ui): show shimmer and icon on initial Working... state for new agent runs
- [`097f30b`](https://github.com/paperclipai/paperclip/commit/097f30b1389f9d46ef288791b101e9407d89f411) feat(ui): nest parent-child issues in inbox/mine view
- [`d3e66c7`](https://github.com/paperclipai/paperclip/commit/d3e66c789e01b45a1d0c840b92e2ade5228f1cf8) feat(ui): add toggle button for inbox parent-child nesting
- [`58ae23a`](https://github.com/paperclipai/paperclip/commit/58ae23aa2c6607f9ae86b6064a66c9390fb20da7) fix(ui): make j/k keyboard shortcuts traverse nested child issues in inbox
- [`2cf2a44`](https://github.com/paperclipai/paperclip/commit/2cf2a44d68f0496b3354bf6e2b6a99602e87517d) fix(ui): fix inbox nesting column alignment
- [`ede3206`](https://github.com/paperclipai/paperclip/commit/ede320642328bc859a173db81753cacfe91020f7) fix(ui): always render transcript message for non-succeeded runs
- [`69ff793`](https://github.com/paperclipai/paperclip/commit/69ff793c6a68b3434d8eb612899eed432ccb5ea7) Add issue-detail g i inbox shortcut
- [`fad5634`](https://github.com/paperclipai/paperclip/commit/fad5634b29af5d1627cb6449519176e01eac71bf) feat(ui): add keyboard shortcut cheatsheet dialog on ? keypress
- [`2960336`](https://github.com/paperclipai/paperclip/commit/296033620f6d86410f8390f2e0adac2fe8b22260) Remove main-content focus outline
- [`e21e442`](https://github.com/paperclipai/paperclip/commit/e21e442033219dc54d0e6e3557853aae4aae98c5) Fix issue detail inbox archive shortcut
- [`59d913d`](https://github.com/paperclipai/paperclip/commit/59d913d04b95a0b841e11a79e8dfebdda4e77ed9) Fix issue detail main-pane focus on navigation
- [`15b0f11`](https://github.com/paperclipai/paperclip/commit/15b0f112756aef51f43e41a132a962a1bde035bf) Keep issue chat composer visible while typing
- [`1079f21`](https://github.com/paperclipai/paperclip/commit/1079f21ac412fab7f17758af9f4ab796bf352b76) Add issue detail shortcut for comment composer
- [`cbc2373`](https://github.com/paperclipai/paperclip/commit/cbc237311ff27c18c92b1a0451de273d8bcd5a56) Fix interrupted issue chat rerender
- [`ba5cb34`](https://github.com/paperclipai/paperclip/commit/ba5cb34bed14358c7974a7f5c4413731aeee10df) Tighten issue chat composer height cap
- [`e15b541`](https://github.com/paperclipai/paperclip/commit/e15b5412ec16bc1c0872a26c941d91066b414795) Prevent g c from leaking into global shortcuts
- [`f44c951`](https://github.com/paperclipai/paperclip/commit/f44c951a225b1d73c9a85ea863738b84cd2a8033) Make issue chat composer inline again
- [`2ebbad6`](https://github.com/paperclipai/paperclip/commit/2ebbad656134b339f73a2d22f2c85be7032486ce) Add breathing room when focusing comment composer
- [`d82468d`](https://github.com/paperclipai/paperclip/commit/d82468d6e580f6bb35e5f0242fb883a198887994) Keep interrupted runs stable in issue chat
- [`efc1e33`](https://github.com/paperclipai/paperclip/commit/efc1e336b0ee6a80685dbbd124bcdb2720efcf29) Improve issue detail load stability
- [`de1cd58`](https://github.com/paperclipai/paperclip/commit/de1cd5858d90b1ce3a4d1176aa9a816cfbdde720) Add explicit review start action in issue sidebar
- [`a4b05d8`](https://github.com/paperclipai/paperclip/commit/a4b05d883178515448e260ddb72658cb49d23624) Guard issue chat against assistant-ui crashes
- [`9e8cd28`](https://github.com/paperclipai/paperclip/commit/9e8cd28f81d7e382cb88b4e231345f51aefe2703) Speed up issue detail comments and refreshes
- [`996c7eb`](https://github.com/paperclipai/paperclip/commit/996c7eb7278eabb71780810468ff2eb6ad5b52f6) Disable inbox nesting on mobile
- [`327eadb`](https://github.com/paperclipai/paperclip/commit/327eadb45cc65cc85be4643d68ae19403ac7e7a9) fix(ui): harden issue comment editor sync
- [`fe21ab3`](https://github.com/paperclipai/paperclip/commit/fe21ab324b7863c72d502f29f38721b20d9d948c) test(server): isolate route modules in endpoint tests
- [`1ac1dbc`](https://github.com/paperclipai/paperclip/commit/1ac1dbcb3e7eab8babebace4f1b994aef0680986) fix(ui): repair issue detail split regressions
- [`0ed3f56`](https://github.com/paperclipai/paperclip/commit/0ed3f569356637237baf85593b1e140b40b880d1) fix(ci): run workspace preflight through server toolchain
- [`11c3eee`](https://github.com/paperclipai/paperclip/commit/11c3eee66b49d5186a2a6876432a00f3497bc096) test(server): align isolated route specs with current behavior
- [`ce3bc32`](https://github.com/paperclipai/paperclip/commit/ce3bc329fc3c132addca6cbe742595103dd77660) test(ui): align inbox badge fixture with dismissal state
- [`61ed4ef`](https://github.com/paperclipai/paperclip/commit/61ed4ef90c5a94a910b905766cb2e155d172f117) fix(server): reject non-participant stage mutations
- [`d607ca0`](https://github.com/paperclipai/paperclip/commit/d607ca0089fe349b81f2913c564cbf98683066da) Scope workspace link preflight to linked worktrees
- [`c7bf266`](https://github.com/paperclipai/paperclip/commit/c7bf2661c982b58db18956bbf320e5310717b8f9) Remove workspace link package preflight hooks
- [`781d9dc`](https://github.com/paperclipai/paperclip/commit/781d9dcf7401b29d8fc240ec762ab2f71ad9c66f) Merge pull request #3204 from cryppadotta/pap-1239-runtime-backend
- [`b578bf1`](https://github.com/paperclipai/paperclip/commit/b578bf1f51a4dd4ecb0d928ef065b8d00bc13a02) Merge public-gh/master into pap-1239-ui-ux
- [`0191fab`](https://github.com/paperclipai/paperclip/commit/0191fabdc671a5fe1df66c44036a2a907149d056) Merge pull request #3203 from cryppadotta/pap-1239-tooling-docs
- [`264eb34`](https://github.com/paperclipai/paperclip/commit/264eb34f248dee1b750e8ce8cba938c55c66ebfd) Merge pull request #3205 from cryppadotta/pap-1239-ui-ux
- [`da251e5`](https://github.com/paperclipai/paperclip/commit/da251e5eab536a946f5d6f92829a754ada62f05e) Merge public/master into pap-1239-server-test-isolation
- [`b4a58ba`](https://github.com/paperclipai/paperclip/commit/b4a58ba8a61c6c62c29aeee1efe9997911f514be) Merge pull request #3206 from cryppadotta/pap-1239-server-test-isolation
- [`5d02158`](https://github.com/paperclipai/paperclip/commit/5d021583befc7e3493b3179b45c3b314dd83fba8) Add draft routine defaults and run-time overrides
- [`03dff1a`](https://github.com/paperclipai/paperclip/commit/03dff1a29afaebe8705027e17926175aec9ec5bc) Refine issue workflow surfaces and live updates
- [`3cee1f1`](https://github.com/paperclipai/paperclip/commit/3cee1f12dab45594e85cbd9fbe9a3af5af182789) test(ui): wait for workspace selector in new issue dialog test
- [`6d63a4d`](https://github.com/paperclipai/paperclip/commit/6d63a4df454df3036fb6efc1bc63dc963901e2e7) Merge pull request #3220 from paperclipai/pap-1266-routines
- [`44d94d0`](https://github.com/paperclipai/paperclip/commit/44d94d0add78b3390874ab90c3f3a1a303dc8499) fix(ui): persist cleared agent env bindings on save
- [`4077ccd`](https://github.com/paperclipai/paperclip/commit/4077ccd343464d651469e80164b9a2b522d422f1) Fix signoff stage access and comment wake retries
- [`0e87fdb`](https://github.com/paperclipai/paperclip/commit/0e87fdbe353d695733e33725ea964537f83db89f) Merge pull request #3222 from paperclipai/pap-1266-issue-workflow
- [`7c42345`](https://github.com/paperclipai/paperclip/commit/7c42345177567882ca643f8d7d8caf5c89738d5e) chore: re-trigger CI to refresh PR base SHA
- [`724893a`](https://github.com/paperclipai/paperclip/commit/724893ad5b5dc5164a2538881fdde52508230be8) fix claude instruction sibling path hint
- [`4477ca2`](https://github.com/paperclipai/paperclip/commit/4477ca2a7e5b82ebd40a74e62b35bab2bcda6422) Merge pull request #3299 from aronprins/codex/fix-ceo-instruction-relative-paths
- [`ac664df`](https://github.com/paperclipai/paperclip/commit/ac664df8e48326135a913e97ee7ed937d913586b) fix(authz): scope import, approvals, activity, and heartbeat routes (#3315)
- [`b00d52c`](https://github.com/paperclipai/paperclip/commit/b00d52c5b6508c8cca61c68873758b02890df314) Merge pull request #3015 from aronprins/feature/backups-configuration
- [`f4a05dc`](https://github.com/paperclipai/paperclip/commit/f4a05dc35c2eb80511d56c68c0dd270b16799040) fix(cli): prepare plugin sdk before cli dev boot (#3343)
- [`5487212`](https://github.com/paperclipai/paperclip/commit/548721248e4a0740e33033e223b0ca82db6a7142) fix(ui): keep latest issue document revision current (#3342)
- [`dab9574`](https://github.com/paperclipai/paperclip/commit/dab95740be90dc133d345dc7e7ed6626bddccc7a) feat: polish inbox and issue list workflows
- [`c566a92`](https://github.com/paperclipai/paperclip/commit/c566a9236c8b815ed61abdefa4798687e6277449) fix: harden heartbeat and adapter runtime workflows
- [`958c116`](https://github.com/paperclipai/paperclip/commit/958c11699e28d7fec77a16bfafd81f216ff5b208) feat: polish issue thread markdown and references
- [`8bdf408`](https://github.com/paperclipai/paperclip/commit/8bdf4081ee45f76840b44e52b77a2f4e80b8a1f6) chore: improve worktree tooling and security docs
- [`8cb70d8`](https://github.com/paperclipai/paperclip/commit/8cb70d897d6b41cd6b3bc8578b1bcc9fc09cec4c) fix: use CLI tsx entrypoint for workspace preflight
- [`7ec8716`](https://github.com/paperclipai/paperclip/commit/7ec87161597406df6d4fc11dbded8f3ccc536d58) fix: keep inbox quicklook and tests standalone
- [`0162bb3`](https://github.com/paperclipai/paperclip/commit/0162bb332c5297a7520b3b479329baf53279497a) fix: keep runtime UI changes self-contained
- [`dc94e3d`](https://github.com/paperclipai/paperclip/commit/dc94e3d1dfb200f5a327d7f428564294e97da299) fix: keep thread polish independent of quicklook routing
- [`65480ff`](https://github.com/paperclipai/paperclip/commit/65480ffab134b82e70496814d17ca5c058cdf46b) fix: restore inbox optimistic run fixture
- [`1cd0281`](https://github.com/paperclipai/paperclip/commit/1cd0281b4d6c7c18e50fa06901a60154633a7d07) test(ui): fix heartbeat run fixture drift
- [`62d05a7`](https://github.com/paperclipai/paperclip/commit/62d05a7ae2b969a088be58a71fae5073ab1bf47f) Merge pull request #3232 from officialasishkumar/fix/clear-empty-agent-env-bindings
- [`aaf42f3`](https://github.com/paperclipai/paperclip/commit/aaf42f3a7e342c104d49a589161066ac76b22b74) Merge pull request #3353 from cryppadotta/pap-1331-dev-tools-docs
- [`dae888c`](https://github.com/paperclipai/paperclip/commit/dae888cc5d21b04ec4c7f5142dd655dbeacd445b) Merge pull request #3354 from cryppadotta/pap-1331-runtime-workflows
- [`45ebeca`](https://github.com/paperclipai/paperclip/commit/45ebecab5a3d404970f555d1750dc73cf2b3a2be) Merge pull request #3356 from cryppadotta/pap-1331-inbox-ux
- [`b48be80`](https://github.com/paperclipai/paperclip/commit/b48be80d5d1837ca2848ca7ce227b15bc201ec7e) fix: address PR 3355 review regressions
- [`e1bf9d6`](https://github.com/paperclipai/paperclip/commit/e1bf9d66a7e9010c53b39342fecc84adb9682b67) Merge pull request #3355 from cryppadotta/pap-1331-issue-thread-ux
- [`2a84e53`](https://github.com/paperclipai/paperclip/commit/2a84e53c1b82159a3b3ea27daa9a91d4dcde6cf2) Introduce bind presets for deployment setup
- [`6208899`](https://github.com/paperclipai/paperclip/commit/6208899d0a5177e37bb073decb2c3edede0525e3) Fix dev runner workspace import regression
- [`a772068`](https://github.com/paperclipai/paperclip/commit/a77206812e2b58ca45f7440935c107f912eddc5e) Harden tailnet bind setup
- [`03a2cf5`](https://github.com/paperclipai/paperclip/commit/03a2cf5c8acf9bc75c9ba5e6bfda6905190d59a0) Merge pull request #3303 from cryppadotta/PAP-438-review-openclaw-s-docs-on-networking-discovery-and-binding-what-could-we-learn-from-this
- [`2d8f97f`](https://github.com/paperclipai/paperclip/commit/2d8f97feb09cb8660ea64d34efcfe11c1fa06e59) feat(codex-local): add fast mode support
- [`fcab770`](https://github.com/paperclipai/paperclip/commit/fcab77051806097978b080aaa37980c3498c12f9) Add inbox issue search fallback
- [`1f78e55`](https://github.com/paperclipai/paperclip/commit/1f78e5507238664974735a4c54b187949c3248ea) Broaden comment matches in issue search
- [`b611542`](https://github.com/paperclipai/paperclip/commit/b6115424b1bb326e9925d322c0c6b89d4cc37fc0) fix: isolate dev runner worktree env
- [`a7dc889`](https://github.com/paperclipai/paperclip/commit/a7dc88941be77cc446aa9b79394af5b9c34ecd01) fix(codex-local): avoid fast mode in env probe
- [`a63e847`](https://github.com/paperclipai/paperclip/commit/a63e847525ddf5064ab7e309c8dd0e2c18028e69) fix(inbox): avoid refetching on filter-only changes
- [`a5aed93`](https://github.com/paperclipai/paperclip/commit/a5aed931ab34dacb78f47fd845b60a30a2df7285) fix(dev-runner): tighten worktree env bootstrap
- [`96637a1`](https://github.com/paperclipai/paperclip/commit/96637a1e0976db814bd1a16209a5ea2b1f5881d7) Merge pull request #3385 from paperclipai/pap-1347-inbox-issue-search
- [`a692e37`](https://github.com/paperclipai/paperclip/commit/a692e37f3e6a2e73d759f04e667e3cfa3abd7e19) Merge pull request #3386 from paperclipai/pap-1347-dev-runner-worktree-env
- [`b649bd4`](https://github.com/paperclipai/paperclip/commit/b649bd454fce0c5d9aed64e6b75eb302b5d255ba) Merge pull request #3383 from paperclipai/pap-1347-codex-fast-mode
- [`c1bb938`](https://github.com/paperclipai/paperclip/commit/c1bb9385195a0cb57d18cbbde44daa31b1149688) Auto-checkout scoped issue wakes in the harness
- [`2172476`](https://github.com/paperclipai/paperclip/commit/2172476e84234e8a4772d3416b0d19b89c96d513) Fix linked worktree reuse for execution workspaces
- [`ab5eeca`](https://github.com/paperclipai/paperclip/commit/ab5eeca94e6ae1be98cc67b08a2784e9be0640c2) Fix stale issue live-run state
- [`be82a91`](https://github.com/paperclipai/paperclip/commit/be82a912b2f82af270c5c0a499edb1025dada953) Fix signoff e2e for auto-checked out issues
- [`8e82ac7`](https://github.com/paperclipai/paperclip/commit/8e82ac7e38483e93b633458521fdf1ce425ac69a) Handle harness checkout conflicts gracefully
- [`11de5ae`](https://github.com/paperclipai/paperclip/commit/11de5ae9c9523064a290755c02fb66e4e1c1b1e3) Merge pull request #3538 from paperclipai/PAP-1355-right-now-when-agents-boot-they-re-instructed-to-call-the-api-to-checkout-the-issue-so-that-they-have-exclusive
- [`1729e41`](https://github.com/paperclipai/paperclip/commit/1729e41179152a8077e675c38a1fc822b06f8331) Speed up issue-to-issue navigation
- [`e590471`](https://github.com/paperclipai/paperclip/commit/e59047187b203cdc84a4d681fbeba605f6fc7869) Reset scroll on issue detail navigation
- [`0cb42f4`](https://github.com/paperclipai/paperclip/commit/0cb42f49eafe95c78683e385e70acdfbba4ab7a4) Fix rebased issue detail prefetch typing
- [`6844226`](https://github.com/paperclipai/paperclip/commit/6844226572161a4ea267bfb026b509b88cc66dd5) Address Greptile navigation review
- [`d6b0678`](https://github.com/paperclipai/paperclip/commit/d6b06788f6efacb002791c1a60b4889d7bfdb22d) Merge pull request #3542 from cryppadotta/PAP-1346-faster-issue-to-issue-links
- [`76fe736`](https://github.com/paperclipai/paperclip/commit/76fe736e8ee0e30a03a84f9f480facb33a04efbd) chore: add v2026.410.0 release notes for security release
- [`5d1ed71`](https://github.com/paperclipai/paperclip/commit/5d1ed71779df5622d9fd99ad28816b2da4bdee31) chore: add v2026.410.0 release notes for security release