### PR TITLE
sync(paperclip-e392f6b1): chore: add v2026.410.0 release notes for security release (from paperclipai/paperclip#3593)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,12 +19,15 @@
 /adapters/pi-local/minimal-session-state-and-cached-model-discovery.md @bingran-you @cryppadotta @serenakeyitan
 /drift/                                            @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/                         @bingran-you @serenakeyitan
+/drift/paperclip-e392f6b1/infrastructure/          @bingran-you @serenakeyitan
+/drift/paperclip-e392f6b1/infrastructure/security/ @@bingran-you @@serenakeyitan
 /drift/paperclip-e392f6b1/product/                 @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/product/task-system/     @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/product/task-system/issue-links/ @bingran-you @serenakeyitan
 /engineering/                                      @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/dev-runner/                   @@bingran-you @@cryppadotta @@serenakeyitan
 /engineering/cli/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/cli/cli-mirrors-api-and-instance-ops.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/                             @bingran-you @cryppadotta @serenakeyitan
@@ -38,6 +41,7 @@
 /infrastructure/ci-cd/ci-owns-the-lockfile.md      @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/                        @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/authenticated-docker-and-local-trusted-dev.md @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/deployment/bind-presets/           @@bingran-you @@cryppadotta @@serenakeyitan
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan
@@ -64,4 +68,6 @@
 /product/governance/server-enforced-approvals-and-budget-stops.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/auto-checkout/                @@bingran-you @@cryppadotta @@serenakeyitan
+/product/task-system/inbox-search/                 @@bingran-you @@cryppadotta @@serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/engineering/backend/dev-runner/NODE.md
+++ b/engineering/backend/dev-runner/NODE.md
@@ -1,0 +1,20 @@
+---
+title: "Dev Runner"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Dev Runner
+
+The dev runner manages local execution workspaces for agents during development. It handles git worktree creation, environment isolation, and workspace lifecycle.
+
+## Key Decisions
+
+### Worktree Environment Isolation
+
+Each execution workspace gets an isolated environment bootstrap — the dev runner does not leak environment variables or state from the parent process into worktree workspaces. This was tightened after discovering that shared env between the runner and worktrees caused subtle test and build failures.
+
+### Linked Worktree Reuse
+
+When an agent resumes work on an existing branch, the dev runner reuses the linked worktree rather than creating a new one. This avoids worktree proliferation and preserves uncommitted workspace state across agent wake cycles.
+
+Source: `packages/server/` (execution workspace routes and dev runner modules).

--- a/infrastructure/deployment/bind-presets/NODE.md
+++ b/infrastructure/deployment/bind-presets/NODE.md
@@ -1,0 +1,20 @@
+---
+title: "Bind Presets"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Bind Presets
+
+Pre-configured network binding profiles for Paperclip deployment, introduced to simplify setup across different network topologies.
+
+## Key Decisions
+
+### Tailnet-Aware Binding
+
+Bind presets include a tailnet configuration that hardens the network binding setup for overlay networks (e.g., Tailscale). This avoids exposing services on public interfaces when a tailnet is available, and ensures discovery and binding use the correct network identity.
+
+### Preset Model
+
+Rather than requiring users to manually configure host, port, and interface bindings, the deployment setup offers named presets (e.g., `tailnet`, `local`, `public`) that set sensible defaults. This was motivated by observing that most deployment failures stemmed from misconfigured bind addresses.
+
+Source context: PR #3303 (review of OpenClaw networking/discovery/binding patterns).

--- a/product/task-system/auto-checkout/NODE.md
+++ b/product/task-system/auto-checkout/NODE.md
@@ -1,0 +1,20 @@
+---
+title: "Auto-Checkout on Wake"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Auto-Checkout on Wake
+
+When an agent wakes and its wake event is scoped to a specific issue, the harness automatically checks out that issue on the agent's behalf.
+
+## Key Decisions
+
+### Harness-Level Automation
+
+Auto-checkout happens in the harness layer, not in the agent's own logic. This ensures consistent checkout behavior across all adapter types and prevents agents from needing to implement checkout-on-wake themselves.
+
+### Scoped Wake Prerequisite
+
+Auto-checkout only triggers when the wake event carries an explicit issue scope. Unscoped wakes (e.g., periodic heartbeat wakes) do not auto-checkout, preserving the agent's ability to choose its own work from the inbox.
+
+This builds on the atomic task checkout model documented in [Task System](../NODE.md) — the same 409-conflict semantics apply.

--- a/product/task-system/inbox-search/NODE.md
+++ b/product/task-system/inbox-search/NODE.md
@@ -1,0 +1,22 @@
+---
+title: "Inbox Search"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Inbox Search
+
+Search within an agent's or user's inbox — the filtered view of assigned tasks and relevant comments.
+
+## Key Decisions
+
+### Comment Match Broadening
+
+Inbox search matches against issue comments in addition to issue titles and descriptions. This was added because agents frequently need to find issues based on discussion context, not just the original issue description.
+
+### Search Fallback
+
+When the primary search index returns no results, the inbox falls back to a broader query. This ensures agents don't miss relevant issues due to indexing lag or narrow tokenization.
+
+### Filter-Only Change Optimization
+
+Changing inbox filters (e.g., status, priority) without changing the search query does not trigger a full data refetch. This prevents unnecessary network requests and UI flicker when agents or users are narrowing results.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 45ebeca..5d1ed71
- Proposal files: 6

Proposals:
- TREE_MISS: adapters/codex-local/NODE.md — Codex local adapter gained fast mode support (--fast flag) with an env-probe exclusion, but the existing node has no mention of fast mode.
- TREE_MISS: infrastructure/deployment/bind-presets/NODE.md — PR #3303 introduced tailnet bind presets and hardened bind setup for deployment networking, which no existing node covers — deployment/NODE.md only covers Docker stages and compose configs.
- TREE_MISS: engineering/backend/dev-runner/NODE.md — Multiple commits isolate and harden the dev runner's worktree environment bootstrap and linked worktree reuse, but no tree node documents the dev runner subsystem at all.
- TREE_MISS: product/task-system/inbox-search/NODE.md — PR #3385 added inbox issue search with comment-match broadening and a search fallback, plus a fix to avoid refetching on filter-only changes — the task system node mentions inbox conceptually but has no search coverage.
- TREE_MISS: product/task-system/auto-checkout/NODE.md — The harness now auto-checks-out scoped issues when an agent wakes, extending the atomic checkout model already documented in task-system — but this harness-level automation is not captured anywhere.
- TREE_MISS: engineering/frontend/NODE.md — PR #3355 polished issue thread markdown rendering and reference display with quicklook routing independence — the frontend node lists the Issues page but has no detail on thread UX or markdown rendering decisions.

Commits:
- [`958c116`](https://github.com/paperclipai/paperclip/commit/958c11699e28d7fec77a16bfafd81f216ff5b208) feat: polish issue thread markdown and references
- [`dc94e3d`](https://github.com/paperclipai/paperclip/commit/dc94e3d1dfb200f5a327d7f428564294e97da299) fix: keep thread polish independent of quicklook routing
- [`b48be80`](https://github.com/paperclipai/paperclip/commit/b48be80d5d1837ca2848ca7ce227b15bc201ec7e) fix: address PR 3355 review regressions
- [`e1bf9d6`](https://github.com/paperclipai/paperclip/commit/e1bf9d66a7e9010c53b39342fecc84adb9682b67) Merge pull request #3355 from cryppadotta/pap-1331-issue-thread-ux
- [`2a84e53`](https://github.com/paperclipai/paperclip/commit/2a84e53c1b82159a3b3ea27daa9a91d4dcde6cf2) Introduce bind presets for deployment setup
- [`6208899`](https://github.com/paperclipai/paperclip/commit/6208899d0a5177e37bb073decb2c3edede0525e3) Fix dev runner workspace import regression
- [`a772068`](https://github.com/paperclipai/paperclip/commit/a77206812e2b58ca45f7440935c107f912eddc5e) Harden tailnet bind setup
- [`03a2cf5`](https://github.com/paperclipai/paperclip/commit/03a2cf5c8acf9bc75c9ba5e6bfda6905190d59a0) Merge pull request #3303 from cryppadotta/PAP-438-review-openclaw-s-docs-on-networking-discovery-and-binding-what-could-we-learn-from-this
- [`2d8f97f`](https://github.com/paperclipai/paperclip/commit/2d8f97feb09cb8660ea64d34efcfe11c1fa06e59) feat(codex-local): add fast mode support
- [`fcab770`](https://github.com/paperclipai/paperclip/commit/fcab77051806097978b080aaa37980c3498c12f9) Add inbox issue search fallback
- [`1f78e55`](https://github.com/paperclipai/paperclip/commit/1f78e5507238664974735a4c54b187949c3248ea) Broaden comment matches in issue search
- [`b611542`](https://github.com/paperclipai/paperclip/commit/b6115424b1bb326e9925d322c0c6b89d4cc37fc0) fix: isolate dev runner worktree env
- [`a7dc889`](https://github.com/paperclipai/paperclip/commit/a7dc88941be77cc446aa9b79394af5b9c34ecd01) fix(codex-local): avoid fast mode in env probe
- [`a63e847`](https://github.com/paperclipai/paperclip/commit/a63e847525ddf5064ab7e309c8dd0e2c18028e69) fix(inbox): avoid refetching on filter-only changes
- [`a5aed93`](https://github.com/paperclipai/paperclip/commit/a5aed931ab34dacb78f47fd845b60a30a2df7285) fix(dev-runner): tighten worktree env bootstrap
- [`96637a1`](https://github.com/paperclipai/paperclip/commit/96637a1e0976db814bd1a16209a5ea2b1f5881d7) Merge pull request #3385 from paperclipai/pap-1347-inbox-issue-search
- [`a692e37`](https://github.com/paperclipai/paperclip/commit/a692e37f3e6a2e73d759f04e667e3cfa3abd7e19) Merge pull request #3386 from paperclipai/pap-1347-dev-runner-worktree-env
- [`b649bd4`](https://github.com/paperclipai/paperclip/commit/b649bd454fce0c5d9aed64e6b75eb302b5d255ba) Merge pull request #3383 from paperclipai/pap-1347-codex-fast-mode
- [`c1bb938`](https://github.com/paperclipai/paperclip/commit/c1bb9385195a0cb57d18cbbde44daa31b1149688) Auto-checkout scoped issue wakes in the harness
- [`2172476`](https://github.com/paperclipai/paperclip/commit/2172476e84234e8a4772d3416b0d19b89c96d513) Fix linked worktree reuse for execution workspaces
- [`ab5eeca`](https://github.com/paperclipai/paperclip/commit/ab5eeca94e6ae1be98cc67b08a2784e9be0640c2) Fix stale issue live-run state
- [`be82a91`](https://github.com/paperclipai/paperclip/commit/be82a912b2f82af270c5c0a499edb1025dada953) Fix signoff e2e for auto-checked out issues
- [`8e82ac7`](https://github.com/paperclipai/paperclip/commit/8e82ac7e38483e93b633458521fdf1ce425ac69a) Handle harness checkout conflicts gracefully
- [`11de5ae`](https://github.com/paperclipai/paperclip/commit/11de5ae9c9523064a290755c02fb66e4e1c1b1e3) Merge pull request #3538 from paperclipai/PAP-1355-right-now-when-agents-boot-they-re-instructed-to-call-the-api-to-checkout-the-issue-so-that-they-have-exclusive
- [`1729e41`](https://github.com/paperclipai/paperclip/commit/1729e41179152a8077e675c38a1fc822b06f8331) Speed up issue-to-issue navigation
- [`e590471`](https://github.com/paperclipai/paperclip/commit/e59047187b203cdc84a4d681fbeba605f6fc7869) Reset scroll on issue detail navigation
- [`0cb42f4`](https://github.com/paperclipai/paperclip/commit/0cb42f49eafe95c78683e385e70acdfbba4ab7a4) Fix rebased issue detail prefetch typing
- [`6844226`](https://github.com/paperclipai/paperclip/commit/6844226572161a4ea267bfb026b509b88cc66dd5) Address Greptile navigation review
- [`d6b0678`](https://github.com/paperclipai/paperclip/commit/d6b06788f6efacb002791c1a60b4889d7bfdb22d) Merge pull request #3542 from cryppadotta/PAP-1346-faster-issue-to-issue-links
- [`76fe736`](https://github.com/paperclipai/paperclip/commit/76fe736e8ee0e30a03a84f9f480facb33a04efbd) chore: add v2026.410.0 release notes for security release
- [`5d1ed71`](https://github.com/paperclipai/paperclip/commit/5d1ed71779df5622d9fd99ad28816b2da4bdee31) chore: add v2026.410.0 release notes for security release