### PR TITLE
sync(paperclip-e392f6b1): chore: add v2026.410.0 release notes for security release (from paperclipai/paperclip#3592)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /adapters/claude-local/stream-json-and-headless-permissions.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/                             @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/rpc-quota-and-fresh-skill-injection.md @bingran-you @cryppadotta @serenakeyitan
+/adapters/codex-local/fast-mode/                   @@bingran-you @@cryppadotta @@serenakeyitan
 /adapters/cursor-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/cursor-local/conservative-context-and-session-normalization.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/gemini-local/                            @bingran-you @cryppadotta @serenakeyitan
@@ -19,6 +20,8 @@
 /adapters/pi-local/minimal-session-state-and-cached-model-discovery.md @bingran-you @cryppadotta @serenakeyitan
 /drift/                                            @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/                         @bingran-you @serenakeyitan
+/drift/paperclip-e392f6b1/infrastructure/          @bingran-you @serenakeyitan
+/drift/paperclip-e392f6b1/infrastructure/security/ @@bingran-you @@serenakeyitan
 /drift/paperclip-e392f6b1/product/                 @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/product/task-system/     @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/product/task-system/issue-links/ @bingran-you @serenakeyitan
@@ -29,6 +32,7 @@
 /engineering/cli/cli-mirrors-api-and-instance-ops.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/company-scoped-isolation.md  @bingran-you @cryppadotta @serenakeyitan
+/engineering/dev-runner/                           @@bingran-you @@cryppadotta @@serenakeyitan
 /engineering/frontend/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/api-layer-and-react-query-over-global-state.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/                               @bingran-you @cryppadotta @serenakeyitan
@@ -38,6 +42,7 @@
 /infrastructure/ci-cd/ci-owns-the-lockfile.md      @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/                        @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/authenticated-docker-and-local-trusted-dev.md @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/deployment/bind-presets/           @@bingran-you @@cryppadotta @@serenakeyitan
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan
@@ -58,10 +63,13 @@
 /product/                                          @bingran-you @cryppadotta @serenakeyitan
 /product/agent-model/                              @bingran-you @cryppadotta @serenakeyitan
 /product/agent-model/adapter-defined-agent-internals.md @bingran-you @cryppadotta @serenakeyitan
+/product/agent-model/auto-checkout/                @@bingran-you @@cryppadotta @@serenakeyitan
 /product/company-model/                            @bingran-you @cryppadotta @serenakeyitan
 /product/company-model/company-is-the-top-level-boundary.md @bingran-you @cryppadotta @serenakeyitan
 /product/governance/                               @bingran-you @cryppadotta @serenakeyitan
 /product/governance/server-enforced-approvals-and-budget-stops.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/inbox-search/                 @@bingran-you @@cryppadotta @@serenakeyitan
+/product/task-system/issue-threads/                @@bingran-you @@cryppadotta @@serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/adapters/codex-local/fast-mode/NODE.md
+++ b/adapters/codex-local/fast-mode/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Codex Fast Mode"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Codex Fast Mode
+
+The Codex local adapter supports a **fast mode** flag that reduces startup latency for task execution. When enabled, the adapter skips slower initialization steps to begin work sooner.
+
+## Key Decisions
+
+### Fast mode disabled during environment probe
+
+The adapter's environment-detection step (`env probe`) must run without fast mode. The probe needs the full initialization path to accurately detect the host environment, installed tools, and available capabilities. Running the probe in fast mode would skip checks that inform downstream behavior.
+
+### Opt-in activation
+
+Fast mode is not the default. It is activated when the orchestrator determines that the execution context has already been probed and the environment is known, making the full startup sequence redundant.

--- a/engineering/dev-runner/NODE.md
+++ b/engineering/dev-runner/NODE.md
@@ -1,0 +1,24 @@
+---
+title: "Dev Runner"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Dev Runner
+
+The dev runner manages **execution workspaces** for agent tasks using Git worktrees. It handles workspace creation, environment bootstrap, and cleanup for agents that need an isolated checkout to perform work.
+
+**Source:** Server-side execution infrastructure + CLI `worktree` command
+
+## Key Decisions
+
+### Worktree environment isolation
+
+Each worktree-based execution workspace gets its own isolated environment variables. The dev runner bootstraps a scoped env for each worktree rather than inheriting the parent process environment wholesale. This prevents cross-task env leakage (e.g., one agent's API keys or workspace paths bleeding into another agent's execution context).
+
+### Linked worktree reuse
+
+When a task targets a branch that already has a linked worktree, the dev runner reuses the existing worktree rather than creating a fresh one. This avoids redundant checkouts and preserves in-progress state. The reuse logic validates that the existing worktree is in a clean state before attaching a new execution.
+
+### Workspace import bootstrap
+
+New worktrees go through a bootstrap sequence that imports workspace-level configuration (dependencies, tool paths, adapter settings) into the isolated environment. The import must complete before the agent begins work — partial bootstrap is treated as a failure.

--- a/infrastructure/deployment/bind-presets/NODE.md
+++ b/infrastructure/deployment/bind-presets/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Bind Presets"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Bind Presets
+
+Bind presets are predefined network-binding configurations for Paperclip deployment. They control which interfaces and ports the server listens on, replacing ad-hoc bind address configuration with named, validated presets.
+
+## Key Decisions
+
+### Tailnet bind hardening
+
+A dedicated tailnet preset exists for deployments running behind Tailscale. This preset restricts the server to listen only on the Tailscale interface, preventing accidental exposure on public or LAN interfaces. The hardening step validates that the tailnet interface is present before accepting the configuration.
+
+### Presets over raw bind addresses
+
+Rather than exposing raw `HOST:PORT` configuration, the system uses named presets (e.g., `localhost`, `tailnet`, `all-interfaces`) that encode security-appropriate defaults. This reduces misconfiguration risk — operators pick an intent rather than constructing a network address.

--- a/product/agent-model/auto-checkout/NODE.md
+++ b/product/agent-model/auto-checkout/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Auto-Checkout on Issue Wake"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Auto-Checkout on Issue Wake
+
+When an agent receives a **scoped issue wake** — a signal that a specific issue needs attention — the execution harness automatically checks out the relevant branch or worktree before the agent begins work. This eliminates a manual step where agents had to determine and switch to the correct working context.
+
+## Key Decisions
+
+### Harness-level automation
+
+Auto-checkout is handled by the execution harness, not by individual agents or adapters. This ensures consistent behavior across all agent types — whether Claude, Codex, or any other adapter, the workspace is ready before the agent's first prompt.
+
+### Scoped to issue context
+
+The auto-checkout only activates for issue-scoped wakes, not general agent wakes. This prevents unnecessary workspace churn when an agent is woken for non-issue work (e.g., system health checks, scheduled maintenance tasks).

--- a/product/task-system/inbox-search/NODE.md
+++ b/product/task-system/inbox-search/NODE.md
@@ -1,0 +1,22 @@
+---
+title: "Inbox Issue Search"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Inbox Issue Search
+
+The inbox supports full-text search across issues and their comments. Search queries match against issue titles, descriptions, and comment bodies, allowing agents and humans to find relevant work items without browsing the full list.
+
+## Key Decisions
+
+### Search fallback strategy
+
+When the primary search index returns no results, the inbox falls back to a broader matching strategy. This ensures that recently created issues or issues with unusual formatting are still discoverable.
+
+### Broad comment matching
+
+Issue search includes comment content in its matching scope. Comments are often where actionable context lives (status updates, blockers, decisions), so excluding them from search would hide critical information.
+
+### No refetch on filter-only changes
+
+When the user changes inbox filters (without changing the underlying query), the frontend avoids refetching data from the server. This is a deliberate performance optimization — filter changes operate on the already-fetched dataset client-side, reducing unnecessary network requests and improving perceived responsiveness.

--- a/product/task-system/issue-threads/NODE.md
+++ b/product/task-system/issue-threads/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Issue Threads"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Issue Threads
+
+Issue threads are the primary conversation surface for tasks. Each issue has a thread of comments rendered as markdown, supporting inline issue references (e.g., `PAP-123`) that resolve to navigable links.
+
+## Key Decisions
+
+### Markdown rendering with issue references
+
+Thread comments are rendered as full markdown with an additional pass that detects issue identifiers and converts them to interactive references. This lets agents and humans cross-reference related work inline without manual link construction.
+
+### Thread rendering independent of quicklook routing
+
+The thread markdown rendering pipeline is decoupled from the quicklook (hover preview) routing system. Thread polish — formatting, reference resolution, styling — operates independently so that changes to quicklook behavior (e.g., popover triggers, preview content) do not regress the base thread display. This separation was introduced explicitly after a regression where quicklook routing changes broke thread rendering.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 45ebeca..5d1ed71
- Proposal files: 6

Proposals:
- TREE_MISS: adapters/codex-local/fast-mode — The codex-local adapter node documents capabilities but has no mention of fast mode, a new execution flag that must be disabled during env probing.
- TREE_MISS: infrastructure/deployment/bind-presets — The deployment node covers Docker and compose modes but has no mention of bind presets or tailnet networking, both introduced as deployment configuration concepts.
- TREE_MISS: engineering/dev-runner — The dev runner is an undocumented subsystem responsible for worktree-based execution workspace management, env isolation, and linked worktree reuse — none of which appear in any existing node.
- TREE_MISS: product/task-system/inbox-search — Inbox issue search with comment matching and fallback strategy is a new feature not covered by any existing task-system or frontend node.
- TREE_MISS: product/task-system/issue-threads — Issue thread markdown rendering, inline issue references, and the architectural decision to decouple thread polish from quicklook routing are not captured anywhere in the tree.
- TREE_MISS: product/agent-model/auto-checkout — Auto-checkout of scoped issue wakes in the harness is a new agent execution behavior not documented in any existing node — it connects task assignment to automatic workspace setup.

Commits:
- [`958c116`](https://github.com/paperclipai/paperclip/commit/958c11699e28d7fec77a16bfafd81f216ff5b208) feat: polish issue thread markdown and references
- [`dc94e3d`](https://github.com/paperclipai/paperclip/commit/dc94e3d1dfb200f5a327d7f428564294e97da299) fix: keep thread polish independent of quicklook routing
- [`b48be80`](https://github.com/paperclipai/paperclip/commit/b48be80d5d1837ca2848ca7ce227b15bc201ec7e) fix: address PR 3355 review regressions
- [`e1bf9d6`](https://github.com/paperclipai/paperclip/commit/e1bf9d66a7e9010c53b39342fecc84adb9682b67) Merge pull request #3355 from cryppadotta/pap-1331-issue-thread-ux
- [`2a84e53`](https://github.com/paperclipai/paperclip/commit/2a84e53c1b82159a3b3ea27daa9a91d4dcde6cf2) Introduce bind presets for deployment setup
- [`6208899`](https://github.com/paperclipai/paperclip/commit/6208899d0a5177e37bb073decb2c3edede0525e3) Fix dev runner workspace import regression
- [`a772068`](https://github.com/paperclipai/paperclip/commit/a77206812e2b58ca45f7440935c107f912eddc5e) Harden tailnet bind setup
- [`03a2cf5`](https://github.com/paperclipai/paperclip/commit/03a2cf5c8acf9bc75c9ba5e6bfda6905190d59a0) Merge pull request #3303 from cryppadotta/PAP-438-review-openclaw-s-docs-on-networking-discovery-and-binding-what-could-we-learn-from-this
- [`2d8f97f`](https://github.com/paperclipai/paperclip/commit/2d8f97feb09cb8660ea64d34efcfe11c1fa06e59) feat(codex-local): add fast mode support
- [`fcab770`](https://github.com/paperclipai/paperclip/commit/fcab77051806097978b080aaa37980c3498c12f9) Add inbox issue search fallback
- [`1f78e55`](https://github.com/paperclipai/paperclip/commit/1f78e5507238664974735a4c54b187949c3248ea) Broaden comment matches in issue search
- [`b611542`](https://github.com/paperclipai/paperclip/commit/b6115424b1bb326e9925d322c0c6b89d4cc37fc0) fix: isolate dev runner worktree env
- [`a7dc889`](https://github.com/paperclipai/paperclip/commit/a7dc88941be77cc446aa9b79394af5b9c34ecd01) fix(codex-local): avoid fast mode in env probe
- [`a63e847`](https://github.com/paperclipai/paperclip/commit/a63e847525ddf5064ab7e309c8dd0e2c18028e69) fix(inbox): avoid refetching on filter-only changes
- [`a5aed93`](https://github.com/paperclipai/paperclip/commit/a5aed931ab34dacb78f47fd845b60a30a2df7285) fix(dev-runner): tighten worktree env bootstrap
- [`96637a1`](https://github.com/paperclipai/paperclip/commit/96637a1e0976db814bd1a16209a5ea2b1f5881d7) Merge pull request #3385 from paperclipai/pap-1347-inbox-issue-search
- [`a692e37`](https://github.com/paperclipai/paperclip/commit/a692e37f3e6a2e73d759f04e667e3cfa3abd7e19) Merge pull request #3386 from paperclipai/pap-1347-dev-runner-worktree-env
- [`b649bd4`](https://github.com/paperclipai/paperclip/commit/b649bd454fce0c5d9aed64e6b75eb302b5d255ba) Merge pull request #3383 from paperclipai/pap-1347-codex-fast-mode
- [`c1bb938`](https://github.com/paperclipai/paperclip/commit/c1bb9385195a0cb57d18cbbde44daa31b1149688) Auto-checkout scoped issue wakes in the harness
- [`2172476`](https://github.com/paperclipai/paperclip/commit/2172476e84234e8a4772d3416b0d19b89c96d513) Fix linked worktree reuse for execution workspaces
- [`ab5eeca`](https://github.com/paperclipai/paperclip/commit/ab5eeca94e6ae1be98cc67b08a2784e9be0640c2) Fix stale issue live-run state
- [`be82a91`](https://github.com/paperclipai/paperclip/commit/be82a912b2f82af270c5c0a499edb1025dada953) Fix signoff e2e for auto-checked out issues
- [`8e82ac7`](https://github.com/paperclipai/paperclip/commit/8e82ac7e38483e93b633458521fdf1ce425ac69a) Handle harness checkout conflicts gracefully
- [`11de5ae`](https://github.com/paperclipai/paperclip/commit/11de5ae9c9523064a290755c02fb66e4e1c1b1e3) Merge pull request #3538 from paperclipai/PAP-1355-right-now-when-agents-boot-they-re-instructed-to-call-the-api-to-checkout-the-issue-so-that-they-have-exclusive
- [`1729e41`](https://github.com/paperclipai/paperclip/commit/1729e41179152a8077e675c38a1fc822b06f8331) Speed up issue-to-issue navigation
- [`e590471`](https://github.com/paperclipai/paperclip/commit/e59047187b203cdc84a4d681fbeba605f6fc7869) Reset scroll on issue detail navigation
- [`0cb42f4`](https://github.com/paperclipai/paperclip/commit/0cb42f49eafe95c78683e385e70acdfbba4ab7a4) Fix rebased issue detail prefetch typing
- [`6844226`](https://github.com/paperclipai/paperclip/commit/6844226572161a4ea267bfb026b509b88cc66dd5) Address Greptile navigation review
- [`d6b0678`](https://github.com/paperclipai/paperclip/commit/d6b06788f6efacb002791c1a60b4889d7bfdb22d) Merge pull request #3542 from cryppadotta/PAP-1346-faster-issue-to-issue-links
- [`76fe736`](https://github.com/paperclipai/paperclip/commit/76fe736e8ee0e30a03a84f9f480facb33a04efbd) chore: add v2026.410.0 release notes for security release
- [`5d1ed71`](https://github.com/paperclipai/paperclip/commit/5d1ed71779df5622d9fd99ad28816b2da4bdee31) chore: add v2026.410.0 release notes for security release