### PR TITLE
sync(paperclip-e392f6b1): feat: polish inbox and issue list workflows (from paperclipai/paperclip#3356)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /adapters/claude-local/stream-json-and-headless-permissions.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/                             @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/rpc-quota-and-fresh-skill-injection.md @bingran-you @cryppadotta @serenakeyitan
+/adapters/codex-local/fast-mode/                   @@bingran-you @@cryppadotta @@serenakeyitan
 /adapters/cursor-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/cursor-local/conservative-context-and-session-normalization.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/gemini-local/                            @bingran-you @cryppadotta @serenakeyitan
@@ -19,6 +20,8 @@
 /adapters/pi-local/minimal-session-state-and-cached-model-discovery.md @bingran-you @cryppadotta @serenakeyitan
 /drift/                                            @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/                         @bingran-you @serenakeyitan
+/drift/paperclip-e392f6b1/infrastructure/          @bingran-you @serenakeyitan
+/drift/paperclip-e392f6b1/infrastructure/security/ @@bingran-you @@serenakeyitan
 /drift/paperclip-e392f6b1/product/                 @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/product/task-system/     @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/product/task-system/issue-links/ @bingran-you @serenakeyitan
@@ -29,8 +32,10 @@
 /engineering/cli/cli-mirrors-api-and-instance-ops.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/company-scoped-isolation.md  @bingran-you @cryppadotta @serenakeyitan
+/engineering/dev-runner/                           @@bingran-you @@cryppadotta @@serenakeyitan
 /engineering/frontend/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/api-layer-and-react-query-over-global-state.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/issue-threads/               @@bingran-you @@cryppadotta @@serenakeyitan
 /engineering/shared/                               @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/const-arrays-and-zero-runtime-dependencies.md @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/                                   @bingran-you @cryppadotta @serenakeyitan
@@ -38,6 +43,7 @@
 /infrastructure/ci-cd/ci-owns-the-lockfile.md      @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/                        @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/authenticated-docker-and-local-trusted-dev.md @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/deployment/bind-presets/           @@bingran-you @@cryppadotta @@serenakeyitan
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan
@@ -64,4 +70,6 @@
 /product/governance/server-enforced-approvals-and-budget-stops.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/inbox/                        @@bingran-you @@cryppadotta @@serenakeyitan
+/product/task-system/scoped-issue-checkout/        @@bingran-you @@cryppadotta @@serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/adapters/codex-local/fast-mode/NODE.md
+++ b/adapters/codex-local/fast-mode/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Codex Fast Mode"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Codex Fast Mode
+
+The Codex Local adapter supports a **fast mode** flag that enables lower-latency responses from the Codex CLI at the cost of reduced reasoning depth.
+
+## Key Decisions
+
+### Fast Mode Suppressed During Environment Probe
+
+Fast mode is explicitly disabled when the adapter runs its environment capability probe (`env probe`). The probe needs full reasoning to reliably detect tooling, runtimes, and workspace state — fast mode's reduced depth produced unreliable probe results. This was discovered during initial integration and hardened as a follow-up fix.
+
+### Activation
+
+Fast mode is passed through as a CLI flag to the spawned `codex` process. It follows the same pattern as other adapter-level capability flags — controlled by the orchestrator, not the agent.

--- a/engineering/dev-runner/NODE.md
+++ b/engineering/dev-runner/NODE.md
@@ -1,0 +1,22 @@
+---
+title: "Dev Runner"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Dev Runner
+
+The dev runner is the subsystem responsible for bootstrapping and managing execution workspaces for agent task runs during local development.
+
+## Key Decisions
+
+### Worktree-Based Isolation
+
+Each execution workspace uses a git worktree to isolate agent work from the main working tree. The dev runner handles worktree creation, environment bootstrapping, and cleanup. Environment variables are scoped per-worktree to prevent cross-contamination between concurrent agent runs.
+
+### Linked Worktree Reuse
+
+When an agent resumes work on the same branch or issue, the dev runner reuses the existing linked worktree rather than creating a new one. This avoids workspace proliferation and preserves uncommitted agent state across session boundaries.
+
+### Workspace Import
+
+The dev runner imports workspace configuration (dependencies, environment, tooling) into each worktree during bootstrap. This import step was hardened to prevent regressions where missing or stale imports caused agent failures in fresh worktrees.

--- a/engineering/frontend/issue-threads/NODE.md
+++ b/engineering/frontend/issue-threads/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Issue Threads"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Issue Threads
+
+Issue threads are the primary communication surface within the task system UI. Each issue has a threaded conversation where agents and humans exchange updates, decisions, and references to other issues.
+
+## Key Decisions
+
+### Markdown and Reference Rendering
+
+Thread messages render full markdown with support for inline issue references (e.g., `PAP-1234`). References are resolved and displayed as navigable links. The markdown rendering was polished to handle edge cases in agent-generated content, which tends to include more code blocks, lists, and cross-references than typical human messages.
+
+### Thread Rendering Independent of Quicklook Routing
+
+The thread rendering pipeline is decoupled from the quicklook (preview panel) routing system. This ensures that thread polish changes — markdown formatting, reference resolution, layout — do not regress or interfere with how issues are opened in the quicklook panel. The separation was introduced after a review regression where thread changes inadvertently affected quicklook navigation.

--- a/infrastructure/deployment/bind-presets/NODE.md
+++ b/infrastructure/deployment/bind-presets/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Bind Presets"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Bind Presets
+
+Pre-configured network binding profiles for Paperclip deployment, including support for tailnet (Tailscale) environments.
+
+## Key Decisions
+
+### Preset-Based Configuration
+
+Rather than requiring operators to manually configure host/port/interface bindings, the deployment setup offers named presets (e.g., local, tailnet) that bundle safe defaults. This reduces misconfiguration risk, especially for non-standard network topologies like Tailscale meshes.
+
+### Tailnet Hardening
+
+The tailnet bind preset was hardened to ensure the server only listens on the Tailscale interface, preventing accidental exposure on public interfaces. This is a security-sensitive default — the preset encodes the principle that tailnet deployments should never be reachable outside the mesh without explicit override.

--- a/product/task-system/inbox/NODE.md
+++ b/product/task-system/inbox/NODE.md
@@ -1,0 +1,22 @@
+---
+title: "Inbox"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Inbox
+
+The inbox is the primary entry point for agents and humans to discover work requiring their attention — issues assigned to them, new comments, and status changes.
+
+## Key Decisions
+
+### Issue Search with Comment Fallback
+
+Inbox search first matches against issue titles and identifiers. When no title match is found, the search falls back to matching against comment content on issues. This fallback was added because agents and humans often remember issues by something said in a comment thread rather than the issue title.
+
+### Broad Comment Matching
+
+Comment search uses broad matching to surface issues where any comment contains the search terms, not just exact phrases. This trades precision for recall — in an agent-heavy workflow, missing a relevant issue is costlier than surfacing a few extra results.
+
+### Filter-Only Changes Skip Refetch
+
+When the user changes inbox filters (e.g., status, assignee) without changing the underlying data query, the inbox avoids refetching from the server. This optimization prevents unnecessary loading states during rapid filter toggling.

--- a/product/task-system/scoped-issue-checkout/NODE.md
+++ b/product/task-system/scoped-issue-checkout/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Scoped Issue Auto-Checkout"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Scoped Issue Auto-Checkout
+
+When an agent wakes (resumes or is assigned work) in the execution harness, the system automatically checks out the git branch associated with the scoped issue. This removes a manual step from the agent workflow and ensures the agent starts in the correct workspace context.
+
+## Key Decisions
+
+### Automatic on Wake
+
+Checkout happens as part of the wake sequence, before the agent receives its task prompt. This guarantees the agent's filesystem state matches the issue it is about to work on, preventing a class of bugs where agents operate on stale or wrong branches.
+
+### Scoped to Issue, Not Agent
+
+The checkout target is determined by the issue's associated branch, not the agent's last-known state. If an agent is reassigned to a different issue, it checks out the new issue's branch. This follows the task-system principle that issues own the work context, not agents.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 45ebeca..5d1ed71
- Proposal files: 6

Proposals:
- TREE_MISS: adapters/codex-local/fast-mode — The Codex Local adapter node has no mention of fast mode support or the decision to suppress it during environment probing, both introduced in this PR.
- TREE_MISS: infrastructure/deployment/bind-presets — The deployment node has no mention of bind presets or tailnet bind configuration, both introduced in this PR to simplify and harden network binding setup.
- TREE_MISS: engineering/dev-runner — Multiple commits fix dev runner workspace import, worktree env isolation, and linked worktree reuse — but no tree node describes the dev runner subsystem or its worktree environment model.
- TREE_MISS: product/task-system/inbox — The inbox is mentioned only as a one-liner in the frontend and task-system nodes — this PR adds search with comment-matching fallback and filter-aware refetch optimization, none of which are captured.
- TREE_MISS: engineering/frontend/issue-threads — The PR polishes issue thread markdown rendering, reference display, and decouples thread rendering from quicklook routing — none of which are captured in any tree node.
- TREE_MISS: product/task-system/scoped-issue-checkout — Auto-checkout of scoped issues when agents wake in the harness is a new orchestration behavior not captured in any existing node.

Commits:
- [`958c116`](https://github.com/paperclipai/paperclip/commit/958c11699e28d7fec77a16bfafd81f216ff5b208) feat: polish issue thread markdown and references
- [`dc94e3d`](https://github.com/paperclipai/paperclip/commit/dc94e3d1dfb200f5a327d7f428564294e97da299) fix: keep thread polish independent of quicklook routing
- [`b48be80`](https://github.com/paperclipai/paperclip/commit/b48be80d5d1837ca2848ca7ce227b15bc201ec7e) fix: address PR 3355 review regressions
- [`e1bf9d6`](https://github.com/paperclipai/paperclip/commit/e1bf9d66a7e9010c53b39342fecc84adb9682b67) Merge pull request #3355 from cryppadotta/pap-1331-issue-thread-ux
- [`2a84e53`](https://github.com/paperclipai/paperclip/commit/2a84e53c1b82159a3b3ea27daa9a91d4dcde6cf2) Introduce bind presets for deployment setup
- [`6208899`](https://github.com/paperclipai/paperclip/commit/6208899d0a5177e37bb073decb2c3edede0525e3) Fix dev runner workspace import regression
- [`a772068`](https://github.com/paperclipai/paperclip/commit/a77206812e2b58ca45f7440935c107f912eddc5e) Harden tailnet bind setup
- [`03a2cf5`](https://github.com/paperclipai/paperclip/commit/03a2cf5c8acf9bc75c9ba5e6bfda6905190d59a0) Merge pull request #3303 from cryppadotta/PAP-438-review-openclaw-s-docs-on-networking-discovery-and-binding-what-could-we-learn-from-this
- [`2d8f97f`](https://github.com/paperclipai/paperclip/commit/2d8f97feb09cb8660ea64d34efcfe11c1fa06e59) feat(codex-local): add fast mode support
- [`fcab770`](https://github.com/paperclipai/paperclip/commit/fcab77051806097978b080aaa37980c3498c12f9) Add inbox issue search fallback
- [`1f78e55`](https://github.com/paperclipai/paperclip/commit/1f78e5507238664974735a4c54b187949c3248ea) Broaden comment matches in issue search
- [`b611542`](https://github.com/paperclipai/paperclip/commit/b6115424b1bb326e9925d322c0c6b89d4cc37fc0) fix: isolate dev runner worktree env
- [`a7dc889`](https://github.com/paperclipai/paperclip/commit/a7dc88941be77cc446aa9b79394af5b9c34ecd01) fix(codex-local): avoid fast mode in env probe
- [`a63e847`](https://github.com/paperclipai/paperclip/commit/a63e847525ddf5064ab7e309c8dd0e2c18028e69) fix(inbox): avoid refetching on filter-only changes
- [`a5aed93`](https://github.com/paperclipai/paperclip/commit/a5aed931ab34dacb78f47fd845b60a30a2df7285) fix(dev-runner): tighten worktree env bootstrap
- [`96637a1`](https://github.com/paperclipai/paperclip/commit/96637a1e0976db814bd1a16209a5ea2b1f5881d7) Merge pull request #3385 from paperclipai/pap-1347-inbox-issue-search
- [`a692e37`](https://github.com/paperclipai/paperclip/commit/a692e37f3e6a2e73d759f04e667e3cfa3abd7e19) Merge pull request #3386 from paperclipai/pap-1347-dev-runner-worktree-env
- [`b649bd4`](https://github.com/paperclipai/paperclip/commit/b649bd454fce0c5d9aed64e6b75eb302b5d255ba) Merge pull request #3383 from paperclipai/pap-1347-codex-fast-mode
- [`c1bb938`](https://github.com/paperclipai/paperclip/commit/c1bb9385195a0cb57d18cbbde44daa31b1149688) Auto-checkout scoped issue wakes in the harness
- [`2172476`](https://github.com/paperclipai/paperclip/commit/2172476e84234e8a4772d3416b0d19b89c96d513) Fix linked worktree reuse for execution workspaces
- [`ab5eeca`](https://github.com/paperclipai/paperclip/commit/ab5eeca94e6ae1be98cc67b08a2784e9be0640c2) Fix stale issue live-run state
- [`be82a91`](https://github.com/paperclipai/paperclip/commit/be82a912b2f82af270c5c0a499edb1025dada953) Fix signoff e2e for auto-checked out issues
- [`8e82ac7`](https://github.com/paperclipai/paperclip/commit/8e82ac7e38483e93b633458521fdf1ce425ac69a) Handle harness checkout conflicts gracefully
- [`11de5ae`](https://github.com/paperclipai/paperclip/commit/11de5ae9c9523064a290755c02fb66e4e1c1b1e3) Merge pull request #3538 from paperclipai/PAP-1355-right-now-when-agents-boot-they-re-instructed-to-call-the-api-to-checkout-the-issue-so-that-they-have-exclusive
- [`1729e41`](https://github.com/paperclipai/paperclip/commit/1729e41179152a8077e675c38a1fc822b06f8331) Speed up issue-to-issue navigation
- [`e590471`](https://github.com/paperclipai/paperclip/commit/e59047187b203cdc84a4d681fbeba605f6fc7869) Reset scroll on issue detail navigation
- [`0cb42f4`](https://github.com/paperclipai/paperclip/commit/0cb42f49eafe95c78683e385e70acdfbba4ab7a4) Fix rebased issue detail prefetch typing
- [`6844226`](https://github.com/paperclipai/paperclip/commit/6844226572161a4ea267bfb026b509b88cc66dd5) Address Greptile navigation review
- [`d6b0678`](https://github.com/paperclipai/paperclip/commit/d6b06788f6efacb002791c1a60b4889d7bfdb22d) Merge pull request #3542 from cryppadotta/PAP-1346-faster-issue-to-issue-links
- [`76fe736`](https://github.com/paperclipai/paperclip/commit/76fe736e8ee0e30a03a84f9f480facb33a04efbd) chore: add v2026.410.0 release notes for security release
- [`5d1ed71`](https://github.com/paperclipai/paperclip/commit/5d1ed71779df5622d9fd99ad28816b2da4bdee31) chore: add v2026.410.0 release notes for security release