### PR TITLE
sync(paperclip-e392f6b1): chore: improve worktree tooling and security docs (from paperclipai/paperclip#3353)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /adapters/claude-local/stream-json-and-headless-permissions.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/                             @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/rpc-quota-and-fresh-skill-injection.md @bingran-you @cryppadotta @serenakeyitan
+/adapters/codex-local/fast-mode/                   @@bingran-you @@cryppadotta @@serenakeyitan
 /adapters/cursor-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/cursor-local/conservative-context-and-session-normalization.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/gemini-local/                            @bingran-you @cryppadotta @serenakeyitan
@@ -19,12 +20,15 @@
 /adapters/pi-local/minimal-session-state-and-cached-model-discovery.md @bingran-you @cryppadotta @serenakeyitan
 /drift/                                            @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/                         @bingran-you @serenakeyitan
+/drift/paperclip-e392f6b1/infrastructure/          @bingran-you @serenakeyitan
+/drift/paperclip-e392f6b1/infrastructure/security/ @@bingran-you @@serenakeyitan
 /drift/paperclip-e392f6b1/product/                 @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/product/task-system/     @bingran-you @serenakeyitan
 /drift/paperclip-e392f6b1/product/task-system/issue-links/ @bingran-you @serenakeyitan
 /engineering/                                      @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/dev-runner/                   @@bingran-you @@cryppadotta @@serenakeyitan
 /engineering/cli/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/cli/cli-mirrors-api-and-instance-ops.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/                             @bingran-you @cryppadotta @serenakeyitan
@@ -38,6 +42,7 @@
 /infrastructure/ci-cd/ci-owns-the-lockfile.md      @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/                        @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/authenticated-docker-and-local-trusted-dev.md @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/deployment/bind-presets/           @@bingran-you @@cryppadotta @@serenakeyitan
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan
@@ -58,10 +63,13 @@
 /product/                                          @bingran-you @cryppadotta @serenakeyitan
 /product/agent-model/                              @bingran-you @cryppadotta @serenakeyitan
 /product/agent-model/adapter-defined-agent-internals.md @bingran-you @cryppadotta @serenakeyitan
+/product/agent-model/auto-checkout/                @@bingran-you @@cryppadotta @@serenakeyitan
 /product/company-model/                            @bingran-you @cryppadotta @serenakeyitan
 /product/company-model/company-is-the-top-level-boundary.md @bingran-you @cryppadotta @serenakeyitan
 /product/governance/                               @bingran-you @cryppadotta @serenakeyitan
 /product/governance/server-enforced-approvals-and-budget-stops.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/inbox-search/                 @@bingran-you @@cryppadotta @@serenakeyitan
+/product/task-system/issue-threads/                @@bingran-you @@cryppadotta @@serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/adapters/codex-local/fast-mode/NODE.md
+++ b/adapters/codex-local/fast-mode/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Codex Fast Mode"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Codex Fast Mode
+
+The Codex local adapter supports a fast mode flag that trades thoroughness for reduced startup latency.
+
+## Key Decisions
+
+### Disabled During Environment Probe
+
+Fast mode must be disabled during environment probe operations. The probe needs accurate host capability detection, and fast mode skips initialization steps that the probe depends on. This is enforced at the adapter level.
+
+### Session-Scoped Toggle
+
+Fast mode is toggled per session, not globally. Different tasks may warrant different speed/quality tradeoffs within the same agent.

--- a/engineering/backend/dev-runner/NODE.md
+++ b/engineering/backend/dev-runner/NODE.md
@@ -1,0 +1,22 @@
+---
+title: "Dev Runner"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Dev Runner
+
+Manages git worktree-based execution workspaces for agent task execution. Each agent execution gets an isolated worktree with its own environment variables.
+
+## Key Decisions
+
+### Worktree Environment Isolation
+
+Environment variables do not leak between worktrees. Each worktree bootstraps its own environment from the workspace configuration, preventing cross-task contamination. This was tightened after a bug where one agent's credentials were visible to another.
+
+### Linked Worktree Reuse
+
+When an agent wakes to continue work on the same issue, the dev runner reuses the existing linked worktree rather than creating a new one. This preserves uncommitted changes, build artifacts, and installed dependencies across wake cycles.
+
+### Workspace Import Bootstrap
+
+Before an agent receives its task prompt, the dev runner runs an import sequence that ensures the worktree has the correct dependencies installed and configuration files in place. This was fixed after a regression where imports failed due to incorrect path resolution.

--- a/infrastructure/deployment/bind-presets/NODE.md
+++ b/infrastructure/deployment/bind-presets/NODE.md
@@ -1,0 +1,24 @@
+---
+title: "Bind Presets"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Bind Presets
+
+Pre-configured network binding profiles that replace raw bind address configuration with validated, security-appropriate presets.
+
+## Presets
+
+- **localhost** — Binds to `127.0.0.1` only. Default for local development.
+- **tailnet** — Binds to the Tailscale interface. Validates the interface is present before accepting configuration.
+- **all-interfaces** — Binds to `0.0.0.0`. Intended for containerized deployments behind a reverse proxy.
+
+## Key Decisions
+
+### Tailnet Interface Hardening
+
+The tailnet preset validates that the Tailscale network interface exists and is active before allowing the bind. This prevents silent failures where the server appears to start but is unreachable over the tailnet.
+
+### Presets Over Raw Addresses
+
+Raw bind addresses are error-prone and security-sensitive. Presets encode security intent (e.g., "only expose on tailnet") rather than requiring operators to know the correct IP or interface name.

--- a/product/agent-model/auto-checkout/NODE.md
+++ b/product/agent-model/auto-checkout/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Auto-Checkout on Issue Wake"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Auto-Checkout on Issue Wake
+
+When an agent wakes for a scoped issue, the execution harness automatically checks out the git branch associated with that issue before the agent receives its task prompt.
+
+## Key Decisions
+
+### Harness-Level, Not Agent-Level
+
+Auto-checkout runs in the harness before the agent starts, not as an agent action. This ensures the agent always begins in the correct workspace context without needing to understand checkout mechanics.
+
+### Scoped Issues Only
+
+Auto-checkout activates only for issue-scoped wakes. General agent wakes (health checks, idle polls) do not trigger checkout. The checkout target follows the issue's branch, not the agent's last-known branch state.

--- a/product/task-system/inbox-search/NODE.md
+++ b/product/task-system/inbox-search/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Inbox Issue Search"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Inbox Issue Search
+
+Full-text search across issues and comments in the inbox view, with a fallback strategy for edge cases.
+
+## Key Decisions
+
+### Comment Body Matching
+
+Search queries match against comment content, not just issue titles and descriptions. This is critical because agents often record key context in thread comments rather than updating the issue description.
+
+### No Refetch on Filter-Only Changes
+
+When the user changes only filter criteria (status, assignee, etc.) without changing the search query, the client applies filters locally without refetching from the server. This prevents unnecessary network requests and keeps the UI responsive.

--- a/product/task-system/issue-threads/NODE.md
+++ b/product/task-system/issue-threads/NODE.md
@@ -1,0 +1,18 @@
+---
+title: "Issue Threads"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Issue Threads
+
+Thread messages on issues render full markdown with inline reference resolution. References like `PAP-1234` are parsed and rendered as navigable links to the referenced issue, agent, or artifact.
+
+## Key Decisions
+
+### Quicklook-Independent Rendering
+
+Thread rendering is decoupled from quicklook routing. Thread messages display identically whether viewed inline, in a detail panel, or via quicklook. This prevents UI regressions where routing context leaks into content rendering.
+
+### Markdown Edge Cases for Agent Content
+
+Agent-generated thread messages often contain code blocks, nested lists, and unusual whitespace. The renderer handles these edge cases to avoid broken display from non-human authorship patterns.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 45ebeca..5d1ed71
- Proposal files: 6

Proposals:
- TREE_MISS: product/task-system/issue-threads — Issue thread markdown rendering with inline reference resolution (PAP-1234 links) and quicklook-independent rendering is not covered by any existing node — issue-links covers link navigation but not thread display.
- TREE_MISS: infrastructure/deployment/bind-presets — Named network binding presets (localhost, tailnet, all-interfaces) with Tailscale interface hardening are not mentioned anywhere in the deployment node.
- TREE_MISS: adapters/codex-local/fast-mode — Codex fast mode support (flag toggling, env probe exclusion) is not documented in the existing codex-local adapter node.
- TREE_MISS: product/task-system/inbox-search — Inbox issue search with comment body matching and filter-only refetch avoidance is not covered by any existing task system node.
- TREE_MISS: engineering/backend/dev-runner — The dev runner subsystem (worktree environment isolation, linked worktree reuse, workspace import bootstrap) is not documented — backend NODE.md only lists execution-workspaces as a route group with no details.
- TREE_MISS: product/agent-model/auto-checkout — Auto-checkout of the scoped issue's branch on agent wake is a new harness-level behavior not documented in the agent model node.

Commits:
- [`958c116`](https://github.com/paperclipai/paperclip/commit/958c11699e28d7fec77a16bfafd81f216ff5b208) feat: polish issue thread markdown and references
- [`dc94e3d`](https://github.com/paperclipai/paperclip/commit/dc94e3d1dfb200f5a327d7f428564294e97da299) fix: keep thread polish independent of quicklook routing
- [`b48be80`](https://github.com/paperclipai/paperclip/commit/b48be80d5d1837ca2848ca7ce227b15bc201ec7e) fix: address PR 3355 review regressions
- [`e1bf9d6`](https://github.com/paperclipai/paperclip/commit/e1bf9d66a7e9010c53b39342fecc84adb9682b67) Merge pull request #3355 from cryppadotta/pap-1331-issue-thread-ux
- [`2a84e53`](https://github.com/paperclipai/paperclip/commit/2a84e53c1b82159a3b3ea27daa9a91d4dcde6cf2) Introduce bind presets for deployment setup
- [`6208899`](https://github.com/paperclipai/paperclip/commit/6208899d0a5177e37bb073decb2c3edede0525e3) Fix dev runner workspace import regression
- [`a772068`](https://github.com/paperclipai/paperclip/commit/a77206812e2b58ca45f7440935c107f912eddc5e) Harden tailnet bind setup
- [`03a2cf5`](https://github.com/paperclipai/paperclip/commit/03a2cf5c8acf9bc75c9ba5e6bfda6905190d59a0) Merge pull request #3303 from cryppadotta/PAP-438-review-openclaw-s-docs-on-networking-discovery-and-binding-what-could-we-learn-from-this
- [`2d8f97f`](https://github.com/paperclipai/paperclip/commit/2d8f97feb09cb8660ea64d34efcfe11c1fa06e59) feat(codex-local): add fast mode support
- [`fcab770`](https://github.com/paperclipai/paperclip/commit/fcab77051806097978b080aaa37980c3498c12f9) Add inbox issue search fallback
- [`1f78e55`](https://github.com/paperclipai/paperclip/commit/1f78e5507238664974735a4c54b187949c3248ea) Broaden comment matches in issue search
- [`b611542`](https://github.com/paperclipai/paperclip/commit/b6115424b1bb326e9925d322c0c6b89d4cc37fc0) fix: isolate dev runner worktree env
- [`a7dc889`](https://github.com/paperclipai/paperclip/commit/a7dc88941be77cc446aa9b79394af5b9c34ecd01) fix(codex-local): avoid fast mode in env probe
- [`a63e847`](https://github.com/paperclipai/paperclip/commit/a63e847525ddf5064ab7e309c8dd0e2c18028e69) fix(inbox): avoid refetching on filter-only changes
- [`a5aed93`](https://github.com/paperclipai/paperclip/commit/a5aed931ab34dacb78f47fd845b60a30a2df7285) fix(dev-runner): tighten worktree env bootstrap
- [`96637a1`](https://github.com/paperclipai/paperclip/commit/96637a1e0976db814bd1a16209a5ea2b1f5881d7) Merge pull request #3385 from paperclipai/pap-1347-inbox-issue-search
- [`a692e37`](https://github.com/paperclipai/paperclip/commit/a692e37f3e6a2e73d759f04e667e3cfa3abd7e19) Merge pull request #3386 from paperclipai/pap-1347-dev-runner-worktree-env
- [`b649bd4`](https://github.com/paperclipai/paperclip/commit/b649bd454fce0c5d9aed64e6b75eb302b5d255ba) Merge pull request #3383 from paperclipai/pap-1347-codex-fast-mode
- [`c1bb938`](https://github.com/paperclipai/paperclip/commit/c1bb9385195a0cb57d18cbbde44daa31b1149688) Auto-checkout scoped issue wakes in the harness
- [`2172476`](https://github.com/paperclipai/paperclip/commit/2172476e84234e8a4772d3416b0d19b89c96d513) Fix linked worktree reuse for execution workspaces
- [`ab5eeca`](https://github.com/paperclipai/paperclip/commit/ab5eeca94e6ae1be98cc67b08a2784e9be0640c2) Fix stale issue live-run state
- [`be82a91`](https://github.com/paperclipai/paperclip/commit/be82a912b2f82af270c5c0a499edb1025dada953) Fix signoff e2e for auto-checked out issues
- [`8e82ac7`](https://github.com/paperclipai/paperclip/commit/8e82ac7e38483e93b633458521fdf1ce425ac69a) Handle harness checkout conflicts gracefully
- [`11de5ae`](https://github.com/paperclipai/paperclip/commit/11de5ae9c9523064a290755c02fb66e4e1c1b1e3) Merge pull request #3538 from paperclipai/PAP-1355-right-now-when-agents-boot-they-re-instructed-to-call-the-api-to-checkout-the-issue-so-that-they-have-exclusive
- [`1729e41`](https://github.com/paperclipai/paperclip/commit/1729e41179152a8077e675c38a1fc822b06f8331) Speed up issue-to-issue navigation
- [`e590471`](https://github.com/paperclipai/paperclip/commit/e59047187b203cdc84a4d681fbeba605f6fc7869) Reset scroll on issue detail navigation
- [`0cb42f4`](https://github.com/paperclipai/paperclip/commit/0cb42f49eafe95c78683e385e70acdfbba4ab7a4) Fix rebased issue detail prefetch typing
- [`6844226`](https://github.com/paperclipai/paperclip/commit/6844226572161a4ea267bfb026b509b88cc66dd5) Address Greptile navigation review
- [`d6b0678`](https://github.com/paperclipai/paperclip/commit/d6b06788f6efacb002791c1a60b4889d7bfdb22d) Merge pull request #3542 from cryppadotta/PAP-1346-faster-issue-to-issue-links
- [`76fe736`](https://github.com/paperclipai/paperclip/commit/76fe736e8ee0e30a03a84f9f480facb33a04efbd) chore: add v2026.410.0 release notes for security release
- [`5d1ed71`](https://github.com/paperclipai/paperclip/commit/5d1ed71779df5622d9fd99ad28816b2da4bdee31) chore: add v2026.410.0 release notes for security release