### PR TITLE
sync(paperclip-e392f6b1): chore: add v2026.410.0 release notes for security release (from paperclipai/paperclip#3592)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /adapters/claude-local/stream-json-and-headless-permissions.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/                             @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/rpc-quota-and-fresh-skill-injection.md @bingran-you @cryppadotta @serenakeyitan
+/adapters/codex-local/fast-mode/                   @@bingran-you @@cryppadotta @@serenakeyitan
 /adapters/cursor-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/cursor-local/conservative-context-and-session-normalization.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/gemini-local/                            @bingran-you @cryppadotta @serenakeyitan
@@ -71,4 +72,5 @@
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/auto-checkout/                @@bingran-you @@cryppadotta @@serenakeyitan
 /product/task-system/inbox-search/                 @@bingran-you @@cryppadotta @@serenakeyitan
+/product/task-system/issue-thread-ux/              @@bingran-you @@cryppadotta @@serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/adapters/codex-local/fast-mode/NODE.md
+++ b/adapters/codex-local/fast-mode/NODE.md
@@ -1,0 +1,20 @@
+---
+title: "Codex Fast Mode"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Codex Fast Mode
+
+Support for Codex CLI's fast mode within the Paperclip adapter, allowing agents to execute with reduced latency at the cost of some reasoning depth.
+
+## Key Decisions
+
+### Fast Mode as an Adapter Capability
+
+The Codex local adapter supports passing fast mode flags to the Codex CLI. This is exposed as a configurable option rather than a hardcoded default, allowing per-execution control over the speed/quality tradeoff.
+
+### Excluded from Environment Probes
+
+Fast mode is explicitly disabled during environment probes (CLI validation and auth checks). Environment probes need reliable, deterministic results to correctly assess whether the Codex CLI is installed and authenticated. Fast mode's reduced reasoning could produce incorrect probe results.
+
+**Rationale:** Environment probes are a correctness-critical path — a false negative would prevent an agent from starting. The latency savings of fast mode are irrelevant for a one-time startup check, but the risk of misdetection is real.

--- a/product/task-system/issue-thread-ux/NODE.md
+++ b/product/task-system/issue-thread-ux/NODE.md
@@ -1,0 +1,25 @@
+---
+title: "Issue Thread UX"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Issue Thread UX
+
+How issue threads render markdown content and cross-references in the Paperclip UI.
+
+## Key Decisions
+
+### Polished Markdown Rendering
+
+Issue thread comments and descriptions render markdown with consistent styling, including proper heading hierarchy, code blocks, and inline formatting. This was polished to ensure agents and humans see the same well-formatted content when reviewing thread history.
+
+### Reference Resolution in Threads
+
+Issue references (e.g., `ENG-123`) within thread comments are resolved and rendered as navigable links. This allows agents and users to follow cross-references directly from the thread without manual lookup. The reference rendering is independent of quicklook routing — thread references work whether or not the quicklook panel is open.
+
+**Rationale:** Agents produce markdown-heavy outputs in issue comments. Consistent rendering and clickable references reduce friction when agents or humans review work history, and prevent misinterpretation of agent-generated content.
+
+## Boundaries
+
+- Thread rendering is a frontend concern — the backend stores raw markdown. Rendering decisions do not affect the API or storage layer.
+- Reference resolution happens at render time, not at write time, so references stay valid even if issue identifiers change.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 45ebeca..5d1ed71
- Proposal files: 2

Proposals:
- TREE_MISS: product/task-system/issue-thread-ux — PR #3355 introduced markdown rendering polish and reference handling for issue threads — no existing node covers issue thread UX, rendering conventions, or how references are displayed in threads.
- TREE_MISS: adapters/codex-local/fast-mode — PR #3383 added fast mode support to the Codex adapter, including env probe exclusion — the existing codex-local node does not mention fast mode as a capability or decision.

Commits:
- [`958c116`](https://github.com/paperclipai/paperclip/commit/958c11699e28d7fec77a16bfafd81f216ff5b208) feat: polish issue thread markdown and references
- [`dc94e3d`](https://github.com/paperclipai/paperclip/commit/dc94e3d1dfb200f5a327d7f428564294e97da299) fix: keep thread polish independent of quicklook routing
- [`b48be80`](https://github.com/paperclipai/paperclip/commit/b48be80d5d1837ca2848ca7ce227b15bc201ec7e) fix: address PR 3355 review regressions
- [`e1bf9d6`](https://github.com/paperclipai/paperclip/commit/e1bf9d66a7e9010c53b39342fecc84adb9682b67) Merge pull request #3355 from cryppadotta/pap-1331-issue-thread-ux
- [`2a84e53`](https://github.com/paperclipai/paperclip/commit/2a84e53c1b82159a3b3ea27daa9a91d4dcde6cf2) Introduce bind presets for deployment setup
- [`6208899`](https://github.com/paperclipai/paperclip/commit/6208899d0a5177e37bb073decb2c3edede0525e3) Fix dev runner workspace import regression
- [`a772068`](https://github.com/paperclipai/paperclip/commit/a77206812e2b58ca45f7440935c107f912eddc5e) Harden tailnet bind setup
- [`03a2cf5`](https://github.com/paperclipai/paperclip/commit/03a2cf5c8acf9bc75c9ba5e6bfda6905190d59a0) Merge pull request #3303 from cryppadotta/PAP-438-review-openclaw-s-docs-on-networking-discovery-and-binding-what-could-we-learn-from-this
- [`2d8f97f`](https://github.com/paperclipai/paperclip/commit/2d8f97feb09cb8660ea64d34efcfe11c1fa06e59) feat(codex-local): add fast mode support
- [`fcab770`](https://github.com/paperclipai/paperclip/commit/fcab77051806097978b080aaa37980c3498c12f9) Add inbox issue search fallback
- [`1f78e55`](https://github.com/paperclipai/paperclip/commit/1f78e5507238664974735a4c54b187949c3248ea) Broaden comment matches in issue search
- [`b611542`](https://github.com/paperclipai/paperclip/commit/b6115424b1bb326e9925d322c0c6b89d4cc37fc0) fix: isolate dev runner worktree env
- [`a7dc889`](https://github.com/paperclipai/paperclip/commit/a7dc88941be77cc446aa9b79394af5b9c34ecd01) fix(codex-local): avoid fast mode in env probe
- [`a63e847`](https://github.com/paperclipai/paperclip/commit/a63e847525ddf5064ab7e309c8dd0e2c18028e69) fix(inbox): avoid refetching on filter-only changes
- [`a5aed93`](https://github.com/paperclipai/paperclip/commit/a5aed931ab34dacb78f47fd845b60a30a2df7285) fix(dev-runner): tighten worktree env bootstrap
- [`96637a1`](https://github.com/paperclipai/paperclip/commit/96637a1e0976db814bd1a16209a5ea2b1f5881d7) Merge pull request #3385 from paperclipai/pap-1347-inbox-issue-search
- [`a692e37`](https://github.com/paperclipai/paperclip/commit/a692e37f3e6a2e73d759f04e667e3cfa3abd7e19) Merge pull request #3386 from paperclipai/pap-1347-dev-runner-worktree-env
- [`b649bd4`](https://github.com/paperclipai/paperclip/commit/b649bd454fce0c5d9aed64e6b75eb302b5d255ba) Merge pull request #3383 from paperclipai/pap-1347-codex-fast-mode
- [`c1bb938`](https://github.com/paperclipai/paperclip/commit/c1bb9385195a0cb57d18cbbde44daa31b1149688) Auto-checkout scoped issue wakes in the harness
- [`2172476`](https://github.com/paperclipai/paperclip/commit/2172476e84234e8a4772d3416b0d19b89c96d513) Fix linked worktree reuse for execution workspaces
- [`ab5eeca`](https://github.com/paperclipai/paperclip/commit/ab5eeca94e6ae1be98cc67b08a2784e9be0640c2) Fix stale issue live-run state
- [`be82a91`](https://github.com/paperclipai/paperclip/commit/be82a912b2f82af270c5c0a499edb1025dada953) Fix signoff e2e for auto-checked out issues
- [`8e82ac7`](https://github.com/paperclipai/paperclip/commit/8e82ac7e38483e93b633458521fdf1ce425ac69a) Handle harness checkout conflicts gracefully
- [`11de5ae`](https://github.com/paperclipai/paperclip/commit/11de5ae9c9523064a290755c02fb66e4e1c1b1e3) Merge pull request #3538 from paperclipai/PAP-1355-right-now-when-agents-boot-they-re-instructed-to-call-the-api-to-checkout-the-issue-so-that-they-have-exclusive
- [`1729e41`](https://github.com/paperclipai/paperclip/commit/1729e41179152a8077e675c38a1fc822b06f8331) Speed up issue-to-issue navigation
- [`e590471`](https://github.com/paperclipai/paperclip/commit/e59047187b203cdc84a4d681fbeba605f6fc7869) Reset scroll on issue detail navigation
- [`0cb42f4`](https://github.com/paperclipai/paperclip/commit/0cb42f49eafe95c78683e385e70acdfbba4ab7a4) Fix rebased issue detail prefetch typing
- [`6844226`](https://github.com/paperclipai/paperclip/commit/6844226572161a4ea267bfb026b509b88cc66dd5) Address Greptile navigation review
- [`d6b0678`](https://github.com/paperclipai/paperclip/commit/d6b06788f6efacb002791c1a60b4889d7bfdb22d) Merge pull request #3542 from cryppadotta/PAP-1346-faster-issue-to-issue-links
- [`76fe736`](https://github.com/paperclipai/paperclip/commit/76fe736e8ee0e30a03a84f9f480facb33a04efbd) chore: add v2026.410.0 release notes for security release
- [`5d1ed71`](https://github.com/paperclipai/paperclip/commit/5d1ed71779df5622d9fd99ad28816b2da4bdee31) chore: add v2026.410.0 release notes for security release