### PR TITLE
sync(paperclip-e392f6b1): fix(ui): keep latest issue document revision current (from paperclipai/paperclip#3342)

### DIFF
--- a/engineering/backend/heartbeat-run-orchestration/NODE.md
+++ b/engineering/backend/heartbeat-run-orchestration/NODE.md
@@ -1,0 +1,40 @@
+---
+title: "Heartbeat Run Orchestration"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Heartbeat Run Orchestration
+
+How the backend server schedules, executes, and manages the lifecycle of agent heartbeat runs — the bridge between the heartbeat protocol (product layer) and adapter execution (adapter layer).
+
+**Source:** `server/src/services/heartbeat*`, `server/src/routes/heartbeat*`, related run-management services.
+
+---
+
+## Architecture
+
+### Run Lifecycle
+
+A heartbeat run progresses through defined states: scheduled → executing → completed/failed/timed-out. The orchestration service manages these transitions, emitting `heartbeat_run_events` at each step for observability and audit. State transitions are atomic — a run cannot regress to a prior state.
+
+### Adapter Coordination
+
+The orchestration layer calls the adapter's `execute(ctx)` method and monitors the result. It handles adapter-level failures (process crash, timeout, unexpected exit codes) separately from agent-level failures (agent reports failure but adapter succeeded). This separation enables retry logic that distinguishes transient infrastructure failures from persistent agent errors.
+
+### Failure Handling and Hardening
+
+Run orchestration includes guards against edge cases: duplicate concurrent runs for the same agent, adapter processes that outlive their timeout window, partial results from crashed executions, and race conditions between scheduled heartbeats and manual triggers. These hardening measures ensure the system degrades gracefully rather than producing inconsistent state.
+
+---
+
+## Key Decisions
+
+- **Orchestration lives in backend services, not adapters.** Adapters own execution mechanics; the server owns scheduling, lifecycle, and failure policy. This keeps adapters simple and ensures consistent behavior regardless of which adapter is in use.
+- **Event-sourced run history.** Each state transition produces an immutable event in `heartbeat_run_events`, enabling full reconstruction of any run's lifecycle for debugging and audit.
+
+---
+
+## Boundaries
+
+- The **heartbeat protocol** (when to fire, what context to include) is defined in `product/agent-model`. This node covers the **execution** of that protocol.
+- **Adapter execution mechanics** (process spawning, output parsing) are owned by `adapters/`. This node covers the **coordination** around adapter calls.

--- a/engineering/frontend/issue-document-freshness/NODE.md
+++ b/engineering/frontend/issue-document-freshness/NODE.md
@@ -1,0 +1,22 @@
+---
+title: "Issue Document Freshness"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Issue Document Freshness
+
+The issue detail view includes a rich document editor for issue descriptions. When multiple agents or users edit an issue concurrently, the UI must ensure it always displays the latest document revision rather than showing stale content.
+
+## Key Decisions
+
+### Latest Revision Tracking
+
+The frontend tracks document revisions and ensures the displayed content reflects the most recent server state. When a newer revision arrives (via real-time subscription or refetch), the UI updates without requiring a manual refresh. This prevents agents and humans from acting on outdated issue descriptions.
+
+### Non-Destructive Update
+
+When the UI receives a newer revision while the user is not actively editing, it swaps in the latest content. If the user has unsaved local edits, the system must reconcile rather than silently overwrite — though the exact conflict resolution strategy is still evolving.
+
+## Boundaries
+
+This node covers document revision freshness in the issue detail view. Thread comments and their rendering are covered in [issue-thread-ux](../issue-thread-ux/NODE.md). Real-time subscription infrastructure is a backend concern.

--- a/engineering/frontend/issue-list-workflows/NODE.md
+++ b/engineering/frontend/issue-list-workflows/NODE.md
@@ -1,0 +1,27 @@
+---
+title: "Issue List & Board Workflows"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Issue List & Board Workflows
+
+The issue list is the primary surface for browsing, filtering, and acting on issues across a company's task hierarchy. It supports both board-style (kanban) and list-style views.
+
+## Key Patterns
+
+### Inline Workflow Transitions
+
+Users and agents can transition issue status, change assignees, and update priority directly from the list view without opening the detail page. This reduces friction for triage workflows where many issues need quick action.
+
+### Filtering and Grouping
+
+Issue lists support filtering by status, assignee, priority, team, and label. Grouping (e.g., by status column or by assignee) provides different lenses on the same data. These filters map directly to query parameters on the backend issues API.
+
+### Refetch Optimization
+
+Filter-only changes (e.g., toggling a status filter) do not trigger a full data refetch. The frontend distinguishes between filter changes that narrow the existing dataset and changes that require new server data, avoiding unnecessary network requests and UI flicker.
+
+## Key Decisions
+
+- **List and board are views over the same data and API.** Switching between list and board does not change the underlying query — only the rendering.
+- **Filters are URL-driven.** Filter state is encoded in the URL so that views are shareable and bookmarkable.

--- a/product/task-system/issue-links/NODE.md
+++ b/product/task-system/issue-links/NODE.md
@@ -1,0 +1,34 @@
+---
+title: "Issue Links & Dependency Wakeups"
+owners: [@bingran-you, @cryppadotta, @serenakeyitan]
+---
+
+# Issue Links & Dependency Wakeups
+
+Issues can be linked to other issues to express directed relationships — primarily **blocking** and **blocked-by**. These links are the backbone of agent coordination: when a blocking issue resolves, dependent issues are automatically woken up, enabling autonomous agents to resume work without polling or human intervention.
+
+## Key Decisions
+
+### Direct Link Navigation Optimized for Speed
+
+Issue-to-issue links are optimized for fast traversal. When an agent or user views an issue, linked issues are immediately navigable without additional lookups. This was a performance-critical decision — agents frequently need to follow dependency chains across many linked issues, and slow traversal creates bottlenecks in autonomous decision-making.
+
+### Blocking as a First-Class Relationship
+
+Blocking/blocked-by is the primary link type with enforced semantics: a blocked issue cannot proceed until all its blockers are resolved. This is surfaced in the UI (blocker fields in the issue sidebar) and in agent coordination (wakeup events on blocker completion).
+
+**Rationale:** Agents working autonomously need a reliable, structured signal that dependencies are met. Without first-class blocking semantics, agents would need to poll or rely on human coordination.
+
+### Automatic Dependency Wakeups
+
+When a blocking issue transitions to a terminal state (`done` or `cancelled`), the system emits wakeup events to all blocked issues. This triggers assigned agents to re-evaluate and potentially resume work, making the dependency graph an active coordination mechanism rather than passive metadata.
+
+## Boundaries
+
+This node covers link semantics, the blocking model, navigation performance, and the wakeup mechanism. Task hierarchy and status workflows are in the parent [task-system](../NODE.md) node. Frontend rendering of blockers is documented in [issue-thread-ux](../issue-thread-ux/NODE.md).
+
+## Open Questions
+
+- Additional link types beyond blocking (related, duplicate) and their semantics
+- Whether circular blocking dependencies are detected and prevented at creation time
+- Wakeup behavior differences when a blocker is cancelled vs. completed


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 45ebeca..5d1ed71
- Proposal files: 4

Proposals:
- TREE_MISS: engineering/frontend/issue-list-workflows — The tree has no node covering issue list filtering, grouping, inline workflow transitions, or the refetch optimization that avoids re-fetching on filter-only changes — patterns this PR polished.
- TREE_MISS: product/task-system/issue-links — The main tree has no node for issue-to-issue links; the PR shipped link navigation, blocking semantics, and dependency wakeups — currently only in drift, the promoted tree needs this.
- TREE_MISS: engineering/backend/heartbeat-run-orchestration — The tree documents the heartbeat protocol and adapter interfaces but has no node for server-side run orchestration — scheduling, lifecycle state management, failure handling, and the hardening this PR introduced.
- TREE_MISS: engineering/frontend/issue-document-freshness — The PR title fix ensures the UI always displays the latest issue document revision; no existing node or proposal covers document revision tracking or staleness prevention in the issue editor.

Commits:
- [`958c116`](https://github.com/paperclipai/paperclip/commit/958c11699e28d7fec77a16bfafd81f216ff5b208) feat: polish issue thread markdown and references
- [`dc94e3d`](https://github.com/paperclipai/paperclip/commit/dc94e3d1dfb200f5a327d7f428564294e97da299) fix: keep thread polish independent of quicklook routing
- [`b48be80`](https://github.com/paperclipai/paperclip/commit/b48be80d5d1837ca2848ca7ce227b15bc201ec7e) fix: address PR 3355 review regressions
- [`e1bf9d6`](https://github.com/paperclipai/paperclip/commit/e1bf9d66a7e9010c53b39342fecc84adb9682b67) Merge pull request #3355 from cryppadotta/pap-1331-issue-thread-ux
- [`2a84e53`](https://github.com/paperclipai/paperclip/commit/2a84e53c1b82159a3b3ea27daa9a91d4dcde6cf2) Introduce bind presets for deployment setup
- [`6208899`](https://github.com/paperclipai/paperclip/commit/6208899d0a5177e37bb073decb2c3edede0525e3) Fix dev runner workspace import regression
- [`a772068`](https://github.com/paperclipai/paperclip/commit/a77206812e2b58ca45f7440935c107f912eddc5e) Harden tailnet bind setup
- [`03a2cf5`](https://github.com/paperclipai/paperclip/commit/03a2cf5c8acf9bc75c9ba5e6bfda6905190d59a0) Merge pull request #3303 from cryppadotta/PAP-438-review-openclaw-s-docs-on-networking-discovery-and-binding-what-could-we-learn-from-this
- [`2d8f97f`](https://github.com/paperclipai/paperclip/commit/2d8f97feb09cb8660ea64d34efcfe11c1fa06e59) feat(codex-local): add fast mode support
- [`fcab770`](https://github.com/paperclipai/paperclip/commit/fcab77051806097978b080aaa37980c3498c12f9) Add inbox issue search fallback
- [`1f78e55`](https://github.com/paperclipai/paperclip/commit/1f78e5507238664974735a4c54b187949c3248ea) Broaden comment matches in issue search
- [`b611542`](https://github.com/paperclipai/paperclip/commit/b6115424b1bb326e9925d322c0c6b89d4cc37fc0) fix: isolate dev runner worktree env
- [`a7dc889`](https://github.com/paperclipai/paperclip/commit/a7dc88941be77cc446aa9b79394af5b9c34ecd01) fix(codex-local): avoid fast mode in env probe
- [`a63e847`](https://github.com/paperclipai/paperclip/commit/a63e847525ddf5064ab7e309c8dd0e2c18028e69) fix(inbox): avoid refetching on filter-only changes
- [`a5aed93`](https://github.com/paperclipai/paperclip/commit/a5aed931ab34dacb78f47fd845b60a30a2df7285) fix(dev-runner): tighten worktree env bootstrap
- [`96637a1`](https://github.com/paperclipai/paperclip/commit/96637a1e0976db814bd1a16209a5ea2b1f5881d7) Merge pull request #3385 from paperclipai/pap-1347-inbox-issue-search
- [`a692e37`](https://github.com/paperclipai/paperclip/commit/a692e37f3e6a2e73d759f04e667e3cfa3abd7e19) Merge pull request #3386 from paperclipai/pap-1347-dev-runner-worktree-env
- [`b649bd4`](https://github.com/paperclipai/paperclip/commit/b649bd454fce0c5d9aed64e6b75eb302b5d255ba) Merge pull request #3383 from paperclipai/pap-1347-codex-fast-mode
- [`c1bb938`](https://github.com/paperclipai/paperclip/commit/c1bb9385195a0cb57d18cbbde44daa31b1149688) Auto-checkout scoped issue wakes in the harness
- [`2172476`](https://github.com/paperclipai/paperclip/commit/2172476e84234e8a4772d3416b0d19b89c96d513) Fix linked worktree reuse for execution workspaces
- [`ab5eeca`](https://github.com/paperclipai/paperclip/commit/ab5eeca94e6ae1be98cc67b08a2784e9be0640c2) Fix stale issue live-run state
- [`be82a91`](https://github.com/paperclipai/paperclip/commit/be82a912b2f82af270c5c0a499edb1025dada953) Fix signoff e2e for auto-checked out issues
- [`8e82ac7`](https://github.com/paperclipai/paperclip/commit/8e82ac7e38483e93b633458521fdf1ce425ac69a) Handle harness checkout conflicts gracefully
- [`11de5ae`](https://github.com/paperclipai/paperclip/commit/11de5ae9c9523064a290755c02fb66e4e1c1b1e3) Merge pull request #3538 from paperclipai/PAP-1355-right-now-when-agents-boot-they-re-instructed-to-call-the-api-to-checkout-the-issue-so-that-they-have-exclusive
- [`1729e41`](https://github.com/paperclipai/paperclip/commit/1729e41179152a8077e675c38a1fc822b06f8331) Speed up issue-to-issue navigation
- [`e590471`](https://github.com/paperclipai/paperclip/commit/e59047187b203cdc84a4d681fbeba605f6fc7869) Reset scroll on issue detail navigation
- [`0cb42f4`](https://github.com/paperclipai/paperclip/commit/0cb42f49eafe95c78683e385e70acdfbba4ab7a4) Fix rebased issue detail prefetch typing
- [`6844226`](https://github.com/paperclipai/paperclip/commit/6844226572161a4ea267bfb026b509b88cc66dd5) Address Greptile navigation review
- [`d6b0678`](https://github.com/paperclipai/paperclip/commit/d6b06788f6efacb002791c1a60b4889d7bfdb22d) Merge pull request #3542 from cryppadotta/PAP-1346-faster-issue-to-issue-links
- [`76fe736`](https://github.com/paperclipai/paperclip/commit/76fe736e8ee0e30a03a84f9f480facb33a04efbd) chore: add v2026.410.0 release notes for security release
- [`5d1ed71`](https://github.com/paperclipai/paperclip/commit/5d1ed71779df5622d9fd99ad28816b2da4bdee31) chore: add v2026.410.0 release notes for security release