### PR TITLE
fix(tree): salvage nya1 member node from closed sync PR 282

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
 /engineering/cli/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/cli/cli-mirrors-api-and-instance-ops.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/                             @bingran-you @cryppadotta @serenakeyitan
@@ -36,7 +37,10 @@
 /engineering/execution-workspaces/                 @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/api-layer-and-react-query-over-global-state.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/inbox-list/                  @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/issue-document-freshness/    @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-thread-ux/             @bingran-you @cryppadotta @serenakeyitan
+/engineering/mcp/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/                               @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/const-arrays-and-zero-runtime-dependencies.md @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/                                   @bingran-you @cryppadotta @serenakeyitan
@@ -53,6 +57,7 @@
 /members/dotta/                                    @cryppadotta
 /members/henkdz/                                   @HenkDz
 /members/mvanhorn/                                 @mvanhorn
+/members/nya1/                                     @nya1
 /members/serenakeyitan/                            @serenakeyitan
 /members/zvictor/                                  @zvictor
 /plugins/                                          @bingran-you @cryppadotta @serenakeyitan
@@ -69,6 +74,8 @@
 /product/company-model/company-is-the-top-level-boundary.md @bingran-you @cryppadotta @serenakeyitan
 /product/governance/                               @bingran-you @cryppadotta @serenakeyitan
 /product/governance/server-enforced-approvals-and-budget-stops.md @bingran-you @cryppadotta @serenakeyitan
+/product/governance/issue-approvals/               @bingran-you @cryppadotta @serenakeyitan
+/product/routines/                                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/auto-checkout/                @bingran-you @cryppadotta @serenakeyitan

--- a/members/nya1/NODE.md
+++ b/members/nya1/NODE.md
@@ -1,0 +1,12 @@
+---
+title: "nya1"
+owners: [nya1]
+type: "human"
+role: "Contributor"
+domains:
+  - "engineering"
+---
+
+# nya1
+
+Contributor to the Paperclip project.


### PR DESCRIPTION
Supersedes #289 and #288.

The author change here is still only `members/nya1/NODE.md`, but GitHub Actions automatically ran `Update CODEOWNERS` on top of the branch and pushed `.github/CODEOWNERS` as a follow-up commit.

That broader repo-wide CODEOWNERS regeneration remains separate in #286.

Keeping this draft open as the canonical salvage thread for the missing `members/nya1/NODE.md` node.
