### PR TITLE
sync(paperclip-e392f6b1): [codex] harden heartbeat run summaries and recovery context (from paperclipai/paperclip#3742)

### DIFF
--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -69,7 +69,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 - [dev-runner/](dev-runner/) — Local development runner and worktree dev tooling
 - [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
 - [static-asset-serving/](static-asset-serving/) — Static asset cache headers and SPA fallback routing
-- `heartbeat-run-summaries/` — Heartbeat Run Summaries
+- [heartbeat-run-summaries/](heartbeat-run-summaries/) — Per-agent run summary aggregation service built on the heartbeat event log
 
 ## Decision Records
 

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -69,6 +69,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 - [dev-runner/](dev-runner/) — Local development runner and worktree dev tooling
 - [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
 - [static-asset-serving/](static-asset-serving/) — Static asset cache headers and SPA fallback routing
+- `heartbeat-run-summaries/` — Heartbeat Run Summaries
 
 ## Decision Records
 

--- a/engineering/backend/heartbeat-run-summaries/NODE.md
+++ b/engineering/backend/heartbeat-run-summaries/NODE.md
@@ -1,0 +1,33 @@
+---
+title: "Heartbeat Run Summaries"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# Heartbeat Run Summaries
+
+Server-side service that aggregates heartbeat run history into per-agent status snapshots, enabling efficient agent health displays without querying the full event log.
+
+**Source:** `server/src/services/heartbeat-run-summary.ts`, `server/src/routes/agents.ts`
+
+---
+
+## Key Decisions
+
+### Pre-Computed Aggregation Over Raw Event Queries
+
+Rather than requiring API consumers and dashboards to query the full `heartbeat_run_events` log and compute statistics client-side, the server pre-computes run summaries per agent. This enables fast API responses for agent status and health-at-a-glance views.
+
+### Summary Context for Recovery
+
+Run summaries include context that aids process recovery — when an adapter process dies unexpectedly and leaves a run in an executing state, the summary service provides the aggregated state needed to detect and recover orphaned runs. This pairs with the orchestration layer's failure hardening to ensure no run remains permanently stuck.
+
+### Exposed via Agent Routes
+
+Summaries are served through the existing agent routes (`/agents` endpoints) rather than a separate summary API, keeping the API surface cohesive. Consumers querying agent status get summary data inline.
+
+---
+
+## Boundaries
+
+- The **run lifecycle and state machine** are owned by `engineering/backend/heartbeat-run-orchestration`. This node covers the **aggregation and querying** layer built on top of run events.
+- **Process recovery logic** (detecting and recovering orphaned runs) is part of the heartbeat orchestration service. This node provides the **summary context** that recovery depends on.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 5d1ed71..7463479
- Proposal files: 1

Proposals:
- TREE_MISS: engineering/backend/heartbeat-run-summaries/NODE.md — PR #3742 introduces a new heartbeat-run-summary service that pre-computes per-agent run status snapshots and exposes them via agent routes — a new aggregation pattern not covered by the existing heartbeat-run-orchestration node.

Commits:
- [`6e6f538`](https://github.com/paperclipai/paperclip/commit/6e6f5386302045e7df5598cc16705f0e7b0ef76f) [codex] Improve issue detail and issue-list UX (#3678)
- [`e890761`](https://github.com/paperclipai/paperclip/commit/e89076148a577e1b279d0191c7699011488433ce) [codex] Improve workspace runtime and navigation ergonomics (#3680)
- [`7f893ac`](https://github.com/paperclipai/paperclip/commit/7f893ac4ec9f700efaf902be8a57ce510c1c7092) [codex] Harden execution reliability and heartbeat tooling (#3679)
- [`213bcd8`](https://github.com/paperclipai/paperclip/commit/213bcd8c7ab8e4a3839852ff7bd14f4383fc0bac) fix: include routine-execution issues in agent inbox-lite (#3329)
- [`d0a8d4e`](https://github.com/paperclipai/paperclip/commit/d0a8d4e08a5a7d55e0ade6c4906830ae5699b9cb) fix(routines): include cronExpression and timezone in list trigger response (#3209)
- [`b816809`](https://github.com/paperclipai/paperclip/commit/b816809a1e84a2ed7a8fc57fa0223a61814f147d) fix(server): respect externally set PAPERCLIP_API_URL env var (#3472)
- [`f6ce976`](https://github.com/paperclipai/paperclip/commit/f6ce9765449db5ebcf1497530379eb87f135ce81) fix: Anthropic subscription quota always shows 100% used (#3589)
- [`50cd76d`](https://github.com/paperclipai/paperclip/commit/50cd76d8a3f2fc06d1a5af63840abd3d7a1bcd02) feat(adapters): add capability flags to ServerAdapterModule (#3540)
- [`32a9165`](https://github.com/paperclipai/paperclip/commit/32a9165ddf6308f3b46eae0653b6f583e502e538) [codex] harden authenticated routes and issue editor reliability (#3741)
- [`f460f74`](https://github.com/paperclipai/paperclip/commit/f460f744eff5832dc38dc89eb131e3becb229e61) fix: trust PAPERCLIP_PUBLIC_URL in board mutation guard (#3731)
- [`6059c66`](https://github.com/paperclipai/paperclip/commit/6059c665d5ef72e11198981d54cf038a8368c0a6) fix(a11y): remove maximum-scale and user-scalable=no from viewport (#3726)
- [`0d87fd9`](https://github.com/paperclipai/paperclip/commit/0d87fd9a11e4c6d732e8695ece13ddc69b4a6265) fix: proper cache headers for static assets and SPA fallback (#3734)
- [`3905027`](https://github.com/paperclipai/paperclip/commit/390502736c320d6fbeb3f789f52a210a1dfc4a45) chore(ui): drop console.* and legal comments in production builds (#3728)
- [`c1a0249`](https://github.com/paperclipai/paperclip/commit/c1a02497b0a593b35364aa16452bec97d3b86ad9) [codex] fix worktree dev dependency ergonomics (#3743)
- [`3fa5d25`](https://github.com/paperclipai/paperclip/commit/3fa5d25de16a919c3dc3adc6085447efcb880108) [codex] harden heartbeat run summaries and recovery context (#3742)
- [`7463479`](https://github.com/paperclipai/paperclip/commit/7463479fc82904fd1965ba21ad9059195963e406) fix: disable HTTP caching on run log endpoints (#3724)

---

💬 **Reviewer:** comment `@gardener fix` after leaving feedback.
gardener will read your review, push a fix, and reply.
(Or just leave a review — gardener auto-checks every 30 minutes.)