### PR TITLE
sync(paperclip-e392f6b1): [codex] Improve workspace runtime and navigation ergonomics (from paperclipai/paperclip#3680)

### DIFF
--- a/engineering/execution-workspaces/NODE.md
+++ b/engineering/execution-workspaces/NODE.md
@@ -53,6 +53,10 @@ By default, reseed refuses to operate on a target worktree whose Paperclip serve
 
 **Rationale:** Reseed operates on runtime state (config, secrets, instance data) — an ambiguous source could silently copy the wrong instance into a worktree, causing agents to run with mismatched identity. Explicit selectors, the live-target guard, and fail-fast on missing env prevent this class of misconfiguration.
 
+## Sub-domains
+
+- [runtime-services/](runtime-services/) — Typed workspace-command contract (service + job kinds) and runtime service lifecycle
+
 ## Boundaries
 
 - Worktree creation and git operations are the server's responsibility, not the adapter's.

--- a/engineering/execution-workspaces/runtime-services/NODE.md
+++ b/engineering/execution-workspaces/runtime-services/NODE.md
@@ -1,0 +1,29 @@
+---
+title: "Workspace Runtime Services"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# Workspace Runtime Services
+
+How agents manage long-running services and one-shot jobs within execution workspaces, and the typed protocol that coordinates workspace operations between the server and adapters.
+
+**Source:** `packages/shared/src/types/workspace-runtime.ts`, `packages/shared/src/workspace-commands.ts`, `server/src/services/execution-workspaces.ts`, `scripts/provision-worktree.sh`
+
+## Key Decisions
+
+### Typed Workspace Commands Protocol
+
+Workspace operations are classified into two categories: **services** (long-running, supervised processes like dev servers or watchers) and **jobs** (one-shot operations like builds or migrations). The distinction is encoded in a shared type layer (`workspace-runtime.ts`) so both the server and adapters agree on lifecycle semantics — services are expected to run continuously and are monitored, while jobs run to completion and report a result.
+
+### Runtime Service Lifecycle
+
+Runtime services within a workspace are tracked in the `workspace_runtime_services` database table with formalized state transitions. The server manages service startup, health monitoring, and teardown as part of the workspace lifecycle. When a workspace is reclaimed or an agent stops, its associated services are cleaned up.
+
+### Automated Worktree Provisioning
+
+The `provision-worktree.sh` script standardizes worktree setup, replacing ad-hoc manual provisioning. It handles git worktree creation, dependency installation, and environment preparation in a single repeatable step. This is used by both the dev runner and production workspace creation paths.
+
+## Boundaries
+
+- This node covers the *runtime service protocol and lifecycle* within workspaces. The parent node (Execution Workspaces) covers worktree isolation, hardening, and workspace-to-issue linking.
+- Adapter-specific service management (e.g., how Claude vs Codex handles dev servers) belongs in the respective adapter nodes.

--- a/engineering/frontend/NODE.md
+++ b/engineering/frontend/NODE.md
@@ -55,6 +55,14 @@ Pages live in `/ui/src/pages/` and map to top-level routes:
 - **Tailwind v4** (not v3) — uses the new CSS-first configuration approach.
 - **Adapter UI components are co-located with adapter packages** but imported into the main UI bundle for the management pages.
 
+## Sub-domains
+
+- [inbox-list/](inbox-list/) — Inbox list rendering, workspace grouping, and keyboard traversal
+- [issue-document-freshness/](issue-document-freshness/) — Issue document staleness detection and refresh patterns
+- [issue-list-ux/](issue-list-ux/) — Scoped issue list (list + board views), filtering, grouping, inline workflow transitions
+- [issue-thread-ux/](issue-thread-ux/) — Issue detail thread/comment UX
+- [sidebar-preferences/](sidebar-preferences/) — User-scoped and company-scoped sidebar preferences persisted server-side
+
 ## Decision Records
 
 - [api-layer-and-react-query-over-global-state.md](api-layer-and-react-query-over-global-state.md) — Why frontend data flow is organized around a shared API layer plus React Query instead of a global store.

--- a/engineering/frontend/sidebar-preferences/NODE.md
+++ b/engineering/frontend/sidebar-preferences/NODE.md
@@ -1,0 +1,29 @@
+---
+title: "Sidebar Preferences"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# Sidebar Preferences
+
+User-scoped UI preferences for the sidebar, persisted server-side and synchronized across sessions. Covers the full vertical: database schema, API routes, shared validators, and frontend consumption.
+
+**Source:** `packages/db/src/schema/user_sidebar_preferences.ts`, `packages/db/src/schema/company_user_sidebar_preferences.ts`, `server/src/routes/sidebar-preferences.ts`, `packages/shared/src/types/sidebar-preferences.ts`, `packages/shared/src/validators/sidebar-preferences.ts`
+
+## Key Decisions
+
+### Company-Scoped User Preferences
+
+Sidebar preferences use a two-table schema: `user_sidebar_preferences` stores user-level defaults, while `company_user_sidebar_preferences` stores per-company overrides. This follows the existing company-scoped isolation pattern — a user who belongs to multiple companies can have different sidebar layouts in each.
+
+### Dedicated API Surface
+
+Sidebar preferences are served through a dedicated `sidebar-preferences` route module rather than being folded into the existing user or company routes. This keeps the preference CRUD isolated and avoids coupling sidebar concerns with unrelated user/company mutations.
+
+### Shared Validators
+
+Preference shapes are defined once in the shared package (`sidebar-preferences.ts` validators) and consumed by both the API routes and the frontend. This ensures the contract between client and server stays in sync without runtime type mismatches.
+
+## Boundaries
+
+- The sidebar preferences system manages *persistence and retrieval* of preference data. It does not control sidebar rendering or layout logic — that is a frontend concern.
+- Plugin sidebar slots (defined in the Plugin SDK) are separate from user sidebar preferences.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 5d1ed71..7463479
- Proposal files: 2

Proposals:
- TREE_MISS: engineering/frontend/sidebar-preferences — PR adds a full sidebar preferences system (DB schema, shared types/validators, API routes, tests) for persisting user UI state — no existing node covers this.
- TREE_MISS: engineering/execution-workspaces/runtime-services — PR adds workspace-runtime types, workspace-commands protocol, provisioning script, and runtime service docs — extending execution workspaces with runtime service management not covered by the existing node.

Commits:
- [`6e6f538`](https://github.com/paperclipai/paperclip/commit/6e6f5386302045e7df5598cc16705f0e7b0ef76f) [codex] Improve issue detail and issue-list UX (#3678)
- [`e890761`](https://github.com/paperclipai/paperclip/commit/e89076148a577e1b279d0191c7699011488433ce) [codex] Improve workspace runtime and navigation ergonomics (#3680)
- [`7f893ac`](https://github.com/paperclipai/paperclip/commit/7f893ac4ec9f700efaf902be8a57ce510c1c7092) [codex] Harden execution reliability and heartbeat tooling (#3679)
- [`213bcd8`](https://github.com/paperclipai/paperclip/commit/213bcd8c7ab8e4a3839852ff7bd14f4383fc0bac) fix: include routine-execution issues in agent inbox-lite (#3329)
- [`d0a8d4e`](https://github.com/paperclipai/paperclip/commit/d0a8d4e08a5a7d55e0ade6c4906830ae5699b9cb) fix(routines): include cronExpression and timezone in list trigger response (#3209)
- [`b816809`](https://github.com/paperclipai/paperclip/commit/b816809a1e84a2ed7a8fc57fa0223a61814f147d) fix(server): respect externally set PAPERCLIP_API_URL env var (#3472)
- [`f6ce976`](https://github.com/paperclipai/paperclip/commit/f6ce9765449db5ebcf1497530379eb87f135ce81) fix: Anthropic subscription quota always shows 100% used (#3589)
- [`50cd76d`](https://github.com/paperclipai/paperclip/commit/50cd76d8a3f2fc06d1a5af63840abd3d7a1bcd02) feat(adapters): add capability flags to ServerAdapterModule (#3540)
- [`32a9165`](https://github.com/paperclipai/paperclip/commit/32a9165ddf6308f3b46eae0653b6f583e502e538) [codex] harden authenticated routes and issue editor reliability (#3741)
- [`f460f74`](https://github.com/paperclipai/paperclip/commit/f460f744eff5832dc38dc89eb131e3becb229e61) fix: trust PAPERCLIP_PUBLIC_URL in board mutation guard (#3731)
- [`6059c66`](https://github.com/paperclipai/paperclip/commit/6059c665d5ef72e11198981d54cf038a8368c0a6) fix(a11y): remove maximum-scale and user-scalable=no from viewport (#3726)
- [`0d87fd9`](https://github.com/paperclipai/paperclip/commit/0d87fd9a11e4c6d732e8695ece13ddc69b4a6265) fix: proper cache headers for static assets and SPA fallback (#3734)
- [`3905027`](https://github.com/paperclipai/paperclip/commit/390502736c320d6fbeb3f789f52a210a1dfc4a45) chore(ui): drop console.* and legal comments in production builds (#3728)
- [`c1a0249`](https://github.com/paperclipai/paperclip/commit/c1a02497b0a593b35364aa16452bec97d3b86ad9) [codex] fix worktree dev dependency ergonomics (#3743)
- [`3fa5d25`](https://github.com/paperclipai/paperclip/commit/3fa5d25de16a919c3dc3adc6085447efcb880108) [codex] harden heartbeat run summaries and recovery context (#3742)
- [`7463479`](https://github.com/paperclipai/paperclip/commit/7463479fc82904fd1965ba21ad9059195963e406) fix: disable HTTP caching on run log endpoints (#3724)

---

💬 **Reviewer:** comment `@gardener fix` after leaving feedback.
gardener will read your review, push a fix, and reply.
(Or just leave a review — gardener auto-checks every 30 minutes.)