### PR TITLE
sync(paperclip-e392f6b1): feat(adapters): add capability flags to ServerAdapterModule (from paperclipai/paperclip#3540)

### DIFF
--- a/adapters/NODE.md
+++ b/adapters/NODE.md
@@ -74,7 +74,7 @@ All sessioned adapters share a common `sessionCodec` pattern that normalizes fie
 - **[openclaw-gateway/](openclaw-gateway/NODE.md)** — OpenClaw WebSocket gateway adapter
 - **[opencode-local/](opencode-local/NODE.md)** — OpenCode CLI adapter
 - **[pi-local/](pi-local/NODE.md)** — Pi CLI adapter
-- `capability-flags/` — Capability Flags
+- **[capability-flags/](capability-flags/NODE.md)** — Capability flags on ServerAdapterModule for conditional UI rendering
 
 ---
 

--- a/adapters/NODE.md
+++ b/adapters/NODE.md
@@ -74,6 +74,7 @@ All sessioned adapters share a common `sessionCodec` pattern that normalizes fie
 - **[openclaw-gateway/](openclaw-gateway/NODE.md)** — OpenClaw WebSocket gateway adapter
 - **[opencode-local/](opencode-local/NODE.md)** — OpenCode CLI adapter
 - **[pi-local/](pi-local/NODE.md)** — Pi CLI adapter
+- `capability-flags/` — Capability Flags
 
 ---
 

--- a/adapters/capability-flags/NODE.md
+++ b/adapters/capability-flags/NODE.md
@@ -1,0 +1,22 @@
+---
+title: "Capability Flags"
+owners: [bingran-you, cryppadotta, serenakeyitan, cpfarhood]
+---
+
+Adapters declare structured **capability flags** on the `ServerAdapterModule` interface that describe what features each adapter supports at runtime. Unlike `getConfigSchema` (which defines adapter-specific settings UI) or `ADAPTER_SESSION_MANAGEMENT` (which only covers context management), capability flags are a general-purpose mechanism for any boolean or enum capability.
+
+**Source:** `packages/adapter-utils/src/types.ts` (type definitions), `server/src/adapters/registry.ts` (registry exposes capabilities), `server/src/routes/adapters.ts` (API endpoint).
+
+## Architecture
+
+Capability flags flow through three layers:
+
+1. **Declaration** — Each adapter's `ServerAdapterModule` declares its capabilities as structured flags in `adapter-utils/types.ts`. These cover features like session resume support, native context management, skill sync, and fast mode.
+2. **Registry & API** — The adapter registry aggregates capability flags and exposes them through a dedicated adapters API route. This allows any consumer (frontend, CLI, external agents via MCP) to query what a given adapter supports.
+3. **UI consumption** — A React hook (`use-adapter-capabilities.ts`) queries the capabilities API and drives conditional rendering across `AgentConfigForm`, `OnboardingWizard`, `AdapterManager`, and `AgentDetail`. Config options that don't apply to the selected adapter are hidden rather than shown-and-disabled.
+
+## Key Decisions
+
+- **Capability flags on the module interface** rather than a separate config file or database table. Capabilities are inherent to the adapter implementation, so they live next to the code that implements them.
+- **Conditional UI rendering** driven by capabilities rather than adapter-type checks. The frontend never hardcodes adapter names — it queries capability flags, so new adapters get correct UI behavior automatically.
+- **Adapter authoring docs updated** (`docs/adapters/creating-an-adapter.md`) to guide new adapter authors on declaring capability flags.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 5d1ed71..7463479
- Proposal files: 1

Proposals:
- TREE_MISS: adapters/capability-flags/NODE.md — PR #3540 introduces a formal capability flags system on ServerAdapterModule — structured declarations exposed via API and consumed by the UI to conditionally render adapter-specific config — which is not covered by the existing adapters/NODE.md content on getConfigSchema or session management.

Commits:
- [`6e6f538`](https://github.com/paperclipai/paperclip/commit/6e6f5386302045e7df5598cc16705f0e7b0ef76f) [codex] Improve issue detail and issue-list UX (#3678)
- [`e890761`](https://github.com/paperclipai/paperclip/commit/e89076148a577e1b279d0191c7699011488433ce) [codex] Improve workspace runtime and navigation ergonomics (#3680)
- [`7f893ac`](https://github.com/paperclipai/paperclip/commit/7f893ac4ec9f700efaf902be8a57ce510c1c7092) [codex] Harden execution reliability and heartbeat tooling (#3679)
- [`213bcd8`](https://github.com/paperclipai/paperclip/commit/213bcd8c7ab8e4a3839852ff7bd14f4383fc0bac) fix: include routine-execution issues in agent inbox-lite (#3329)
- [`d0a8d4e`](https://github.com/paperclipai/paperclip/commit/d0a8d4e08a5a7d55e0ade6c4906830ae5699b9cb) fix(routines): include cronExpression and timezone in list trigger response (#3209)
- [`b816809`](https://github.com/paperclipai/paperclip/commit/b816809a1e84a2ed7a8fc57fa0223a61814f147d) fix(server): respect externally set PAPERCLIP_API_URL env var (#3472)
- [`f6ce976`](https://github.com/paperclipai/paperclip/commit/f6ce9765449db5ebcf1497530379eb87f135ce81) fix: Anthropic subscription quota always shows 100% used (#3589)
- [`50cd76d`](https://github.com/paperclipai/paperclip/commit/50cd76d8a3f2fc06d1a5af63840abd3d7a1bcd02) feat(adapters): add capability flags to ServerAdapterModule (#3540)
- [`32a9165`](https://github.com/paperclipai/paperclip/commit/32a9165ddf6308f3b46eae0653b6f583e502e538) [codex] harden authenticated routes and issue editor reliability (#3741)
- [`f460f74`](https://github.com/paperclipai/paperclip/commit/f460f744eff5832dc38dc89eb131e3becb229e61) fix: trust PAPERCLIP_PUBLIC_URL in board mutation guard (#3731)
- [`6059c66`](https://github.com/paperclipai/paperclip/commit/6059c665d5ef72e11198981d54cf038a8368c0a6) fix(a11y): remove maximum-scale and user-scalable=no from viewport (#3726)
- [`0d87fd9`](https://github.com/paperclipai/paperclip/commit/0d87fd9a11e4c6d732e8695ece13ddc69b4a6265) fix: proper cache headers for static assets and SPA fallback (#3734)
- [`3905027`](https://github.com/paperclipai/paperclip/commit/390502736c320d6fbeb3f789f52a210a1dfc4a45) chore(ui): drop console.* and legal comments in production builds (#3728)
- [`c1a0249`](https://github.com/paperclipai/paperclip/commit/c1a02497b0a593b35364aa16452bec97d3b86ad9) [codex] fix worktree dev dependency ergonomics (#3743)
- [`3fa5d25`](https://github.com/paperclipai/paperclip/commit/3fa5d25de16a919c3dc3adc6085447efcb880108) [codex] harden heartbeat run summaries and recovery context (#3742)
- [`7463479`](https://github.com/paperclipai/paperclip/commit/7463479fc82904fd1965ba21ad9059195963e406) fix: disable HTTP caching on run log endpoints (#3724)

---

💬 **Reviewer:** comment `@gardener fix` after leaving feedback.
gardener will read your review, push a fix, and reply.
(Or just leave a review — gardener auto-checks every 30 minutes.)