### PR TITLE
sync(paperclip-e392f6b1): [codex] fix worktree dev dependency ergonomics (from paperclipai/paperclip#3743)

### DIFF
--- a/engineering/backend/dev-runner/worktree-dev-tooling/NODE.md
+++ b/engineering/backend/dev-runner/worktree-dev-tooling/NODE.md
@@ -1,27 +1,27 @@
 ---
-title: "Worktree Dev Tooling"
+title: "Dev Environment Tooling"
 owners: [bingran-you, cryppadotta, serenakeyitan]
 ---
 
-# Worktree Dev Tooling
+# Dev Environment Tooling
 
-Dev-time tooling that makes the Paperclip development experience work correctly inside git worktree workspaces. When agents run in isolated worktrees (see Execution Workspaces), standard dev tooling (Vite, pnpm workspace links, HTTP logging) can break because worktrees don't share the same node_modules or file watchers as the main checkout.
+Dev-time tooling that improves the Paperclip development experience, covering asset routing, file-watch filtering, and workspace package link repair. These changes apply broadly to the dev server, not only to worktree-based workflows.
 
 ## Key Decisions
 
-### Workspace Package Link Enforcement
+### Dev Asset Routing Order
 
-A dedicated script (`scripts/ensure-workspace-package-links.ts`) ensures that pnpm workspace symlinks (`workspace:*` protocol) resolve correctly inside worktree directories. Worktrees created by git share the `.git` directory but not `node_modules`, so internal package links can break. This script is run as part of worktree setup to re-establish links.
+In Vite dev mode, the server serves public assets (from `ui/public/`) via `express.static` **before** the HTML shell catch-all handler (`server/src/app.ts`). This ensures that static files like `/sw.js`, `/favicon.ico`, and `/site.webmanifest` are served directly rather than falling through to the Vite HTML transform. The set of known static paths is maintained in `VITE_DEV_STATIC_PATHS`.
 
-### Vite File Watching in Worktrees
+### Vite Dev Watch Filtering
 
-A `vite-watch` utility (`ui/src/lib/vite-watch.ts`) handles file-system watching quirks specific to worktree environments. Standard Vite file watchers may not detect changes correctly when the working directory is a worktree rather than the root checkout.
+A `vite-watch` utility (`ui/src/lib/vite-watch.ts`) reduces unnecessary dev-server work by ignoring test files (`*.test.*`, `*.spec.*`) and test directories (`__tests__/`, `tests/`) during file watching. It also provides a WSL polling fallback for `/mnt/` paths where `inotify` is unavailable. The filtering is general-purpose dev ergonomics, not worktree-specific.
 
-### HTTP Log Policy Middleware
+### Workspace Package Link Repair
 
-An HTTP log policy middleware (`server/src/middleware/http-log-policy.ts`) filters request logging to reduce noise during dev runs inside worktrees, where high-frequency polling and workspace health checks generate excessive log output.
+A script (`scripts/ensure-workspace-package-links.ts`) detects and repairs stale pnpm workspace symlinks (`workspace:*` protocol). The script now runs whenever a workspace-level `node_modules` directory exists, not only inside linked worktree checkouts. This broadens the repair to cover any checkout where workspace links may have gone stale (e.g., after a fresh `pnpm install` or branch switch).
 
 ## Boundaries
 
-- These are dev-time utilities, not production concerns. They are relevant only when running the Paperclip dev server inside worktree workspaces.
+- These are dev-time utilities, not production concerns. They affect only the local development server and build tooling.
 - Worktree creation and lifecycle management remain the responsibility of the Dev Runner and Execution Workspaces modules.

--- a/engineering/backend/dev-runner/worktree-dev-tooling/NODE.md
+++ b/engineering/backend/dev-runner/worktree-dev-tooling/NODE.md
@@ -1,0 +1,27 @@
+---
+title: "Worktree Dev Tooling"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# Worktree Dev Tooling
+
+Dev-time tooling that makes the Paperclip development experience work correctly inside git worktree workspaces. When agents run in isolated worktrees (see Execution Workspaces), standard dev tooling (Vite, pnpm workspace links, HTTP logging) can break because worktrees don't share the same node_modules or file watchers as the main checkout.
+
+## Key Decisions
+
+### Workspace Package Link Enforcement
+
+A dedicated script (`scripts/ensure-workspace-package-links.ts`) ensures that pnpm workspace symlinks (`workspace:*` protocol) resolve correctly inside worktree directories. Worktrees created by git share the `.git` directory but not `node_modules`, so internal package links can break. This script is run as part of worktree setup to re-establish links.
+
+### Vite File Watching in Worktrees
+
+A `vite-watch` utility (`ui/src/lib/vite-watch.ts`) handles file-system watching quirks specific to worktree environments. Standard Vite file watchers may not detect changes correctly when the working directory is a worktree rather than the root checkout.
+
+### HTTP Log Policy Middleware
+
+An HTTP log policy middleware (`server/src/middleware/http-log-policy.ts`) filters request logging to reduce noise during dev runs inside worktrees, where high-frequency polling and workspace health checks generate excessive log output.
+
+## Boundaries
+
+- These are dev-time utilities, not production concerns. They are relevant only when running the Paperclip dev server inside worktree workspaces.
+- Worktree creation and lifecycle management remain the responsibility of the Dev Runner and Execution Workspaces modules.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 5d1ed71..7463479
- Proposal files: 1

Proposals:
- TREE_MISS: engineering/backend/dev-runner/worktree-dev-tooling — PR introduces worktree-aware dev tooling (workspace package linking, vite file watching for worktrees, HTTP log filtering) that represents a pattern not covered by the existing Dev Runner or Execution Workspaces nodes.

Commits:
- [`6e6f538`](https://github.com/paperclipai/paperclip/commit/6e6f5386302045e7df5598cc16705f0e7b0ef76f) [codex] Improve issue detail and issue-list UX (#3678)
- [`e890761`](https://github.com/paperclipai/paperclip/commit/e89076148a577e1b279d0191c7699011488433ce) [codex] Improve workspace runtime and navigation ergonomics (#3680)
- [`7f893ac`](https://github.com/paperclipai/paperclip/commit/7f893ac4ec9f700efaf902be8a57ce510c1c7092) [codex] Harden execution reliability and heartbeat tooling (#3679)
- [`213bcd8`](https://github.com/paperclipai/paperclip/commit/213bcd8c7ab8e4a3839852ff7bd14f4383fc0bac) fix: include routine-execution issues in agent inbox-lite (#3329)
- [`d0a8d4e`](https://github.com/paperclipai/paperclip/commit/d0a8d4e08a5a7d55e0ade6c4906830ae5699b9cb) fix(routines): include cronExpression and timezone in list trigger response (#3209)
- [`b816809`](https://github.com/paperclipai/paperclip/commit/b816809a1e84a2ed7a8fc57fa0223a61814f147d) fix(server): respect externally set PAPERCLIP_API_URL env var (#3472)
- [`f6ce976`](https://github.com/paperclipai/paperclip/commit/f6ce9765449db5ebcf1497530379eb87f135ce81) fix: Anthropic subscription quota always shows 100% used (#3589)
- [`50cd76d`](https://github.com/paperclipai/paperclip/commit/50cd76d8a3f2fc06d1a5af63840abd3d7a1bcd02) feat(adapters): add capability flags to ServerAdapterModule (#3540)
- [`32a9165`](https://github.com/paperclipai/paperclip/commit/32a9165ddf6308f3b46eae0653b6f583e502e538) [codex] harden authenticated routes and issue editor reliability (#3741)
- [`f460f74`](https://github.com/paperclipai/paperclip/commit/f460f744eff5832dc38dc89eb131e3becb229e61) fix: trust PAPERCLIP_PUBLIC_URL in board mutation guard (#3731)
- [`6059c66`](https://github.com/paperclipai/paperclip/commit/6059c665d5ef72e11198981d54cf038a8368c0a6) fix(a11y): remove maximum-scale and user-scalable=no from viewport (#3726)
- [`0d87fd9`](https://github.com/paperclipai/paperclip/commit/0d87fd9a11e4c6d732e8695ece13ddc69b4a6265) fix: proper cache headers for static assets and SPA fallback (#3734)
- [`3905027`](https://github.com/paperclipai/paperclip/commit/390502736c320d6fbeb3f789f52a210a1dfc4a45) chore(ui): drop console.* and legal comments in production builds (#3728)
- [`c1a0249`](https://github.com/paperclipai/paperclip/commit/c1a02497b0a593b35364aa16452bec97d3b86ad9) [codex] fix worktree dev dependency ergonomics (#3743)
- [`3fa5d25`](https://github.com/paperclipai/paperclip/commit/3fa5d25de16a919c3dc3adc6085447efcb880108) [codex] harden heartbeat run summaries and recovery context (#3742)
- [`7463479`](https://github.com/paperclipai/paperclip/commit/7463479fc82904fd1965ba21ad9059195963e406) fix: disable HTTP caching on run log endpoints (#3724)

---

💬 **Reviewer:** comment `@gardener fix` after leaving feedback.
gardener will read your review, push a fix, and reply.
(Or just leave a review — gardener auto-checks every 30 minutes.)