### PR TITLE
sync(paperclip-e392f6b1): fix: proper cache headers for static assets and SPA fallback (from paperclipai/paperclip#3734)

### DIFF
--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -64,6 +64,12 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 - **Agent execution is adapter-driven.** The server never calls LLM APIs directly — it delegates to adapter packages that implement a standard interface.
 - **Secrets are provider-abstracted.** Supports file-based, environment-based, and external secret providers so the same server code works in local dev and cloud deployments.
 
+## Sub-domains
+
+- [dev-runner/](dev-runner/) — Local development runner and worktree dev tooling
+- [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
+- [static-asset-serving/](static-asset-serving/) — Static asset cache headers and SPA fallback routing
+
 ## Decision Records
 
 - [shared-api-and-actor-scoped-authorization.md](shared-api-and-actor-scoped-authorization.md) — Why board and agent traffic share one API surface, with authorization derived from a common request actor model.

--- a/engineering/backend/static-asset-serving/NODE.md
+++ b/engineering/backend/static-asset-serving/NODE.md
@@ -1,0 +1,26 @@
+---
+title: "Static Asset Serving & SPA Fallback"
+owners: [bingran-you, cryppadotta, serenakeyitan, stubbi]
+---
+
+# Static Asset Serving & SPA Fallback
+
+How the Express server serves the built frontend UI when `SERVE_UI=true`.
+
+## Static Asset Cache Headers
+
+The server sets explicit `Cache-Control` headers on static assets (JS, CSS, images, fonts) served from the built UI directory. Hashed assets get long-lived cache headers; non-hashed assets (like `index.html`) get short or no-cache headers to ensure users always get the latest version.
+
+## SPA Fallback
+
+For single-page app routing, the server returns `index.html` for any non-API route that doesn't match a static file. This allows React Router (client-side routing) to handle navigation without 404s. API routes (`/api/*`, `/auth/*`, WebSocket endpoints) are excluded from the fallback and handled by their respective Express route handlers.
+
+## Key Decisions
+
+### Cache-busted assets get aggressive caching
+
+Vite-built assets include content hashes in their filenames, so they can be cached indefinitely. The server leverages this by setting long `max-age` on hashed assets while keeping `index.html` fresh. This is a standard SPA caching pattern that works correctly with CDNs and browser caches.
+
+### Fallback ordering matters
+
+The SPA fallback must be registered after all API routes and static file middleware. If registered too early, it would intercept API requests and return HTML instead of JSON. The ordering in `app.ts` is: API routes → static file middleware → SPA fallback.

--- a/engineering/backend/static-asset-serving/NODE.md
+++ b/engineering/backend/static-asset-serving/NODE.md
@@ -13,7 +13,7 @@ The server sets explicit `Cache-Control` headers on static assets (JS, CSS, imag
 
 ## SPA Fallback
 
-For single-page app routing, the server returns `index.html` for any non-API route that doesn't match a static file. This allows React Router (client-side routing) to handle navigation without 404s. API routes (`/api/*`, `/auth/*`, WebSocket endpoints) are excluded from the fallback and handled by their respective Express route handlers.
+The fallback invariant: non-asset routes can fall back to `index.html`, but missing `/assets/*` paths must return 404. This prevents the HTML shell from being cached as a JS module when the browser requests a hashed asset URL that no longer exists (e.g., after a deploy). API routes (`/api/*`, including `/api/auth/*`) and WebSocket endpoints are excluded from the fallback and handled by their respective Express route handlers.
 
 ## Key Decisions
 


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 5d1ed71..7463479
- Proposal files: 1

Proposals:
- TREE_MISS: engineering/backend/static-asset-serving/NODE.md — The PR adds cache headers for static assets and SPA fallback routing in app.ts, but no existing node documents how the server serves the built UI, its caching strategy, or SPA route handling.

Commits:
- [`6e6f538`](https://github.com/paperclipai/paperclip/commit/6e6f5386302045e7df5598cc16705f0e7b0ef76f) [codex] Improve issue detail and issue-list UX (#3678)
- [`e890761`](https://github.com/paperclipai/paperclip/commit/e89076148a577e1b279d0191c7699011488433ce) [codex] Improve workspace runtime and navigation ergonomics (#3680)
- [`7f893ac`](https://github.com/paperclipai/paperclip/commit/7f893ac4ec9f700efaf902be8a57ce510c1c7092) [codex] Harden execution reliability and heartbeat tooling (#3679)
- [`213bcd8`](https://github.com/paperclipai/paperclip/commit/213bcd8c7ab8e4a3839852ff7bd14f4383fc0bac) fix: include routine-execution issues in agent inbox-lite (#3329)
- [`d0a8d4e`](https://github.com/paperclipai/paperclip/commit/d0a8d4e08a5a7d55e0ade6c4906830ae5699b9cb) fix(routines): include cronExpression and timezone in list trigger response (#3209)
- [`b816809`](https://github.com/paperclipai/paperclip/commit/b816809a1e84a2ed7a8fc57fa0223a61814f147d) fix(server): respect externally set PAPERCLIP_API_URL env var (#3472)
- [`f6ce976`](https://github.com/paperclipai/paperclip/commit/f6ce9765449db5ebcf1497530379eb87f135ce81) fix: Anthropic subscription quota always shows 100% used (#3589)
- [`50cd76d`](https://github.com/paperclipai/paperclip/commit/50cd76d8a3f2fc06d1a5af63840abd3d7a1bcd02) feat(adapters): add capability flags to ServerAdapterModule (#3540)
- [`32a9165`](https://github.com/paperclipai/paperclip/commit/32a9165ddf6308f3b46eae0653b6f583e502e538) [codex] harden authenticated routes and issue editor reliability (#3741)
- [`f460f74`](https://github.com/paperclipai/paperclip/commit/f460f744eff5832dc38dc89eb131e3becb229e61) fix: trust PAPERCLIP_PUBLIC_URL in board mutation guard (#3731)
- [`6059c66`](https://github.com/paperclipai/paperclip/commit/6059c665d5ef72e11198981d54cf038a8368c0a6) fix(a11y): remove maximum-scale and user-scalable=no from viewport (#3726)
- [`0d87fd9`](https://github.com/paperclipai/paperclip/commit/0d87fd9a11e4c6d732e8695ece13ddc69b4a6265) fix: proper cache headers for static assets and SPA fallback (#3734)
- [`3905027`](https://github.com/paperclipai/paperclip/commit/390502736c320d6fbeb3f789f52a210a1dfc4a45) chore(ui): drop console.* and legal comments in production builds (#3728)
- [`c1a0249`](https://github.com/paperclipai/paperclip/commit/c1a02497b0a593b35364aa16452bec97d3b86ad9) [codex] fix worktree dev dependency ergonomics (#3743)
- [`3fa5d25`](https://github.com/paperclipai/paperclip/commit/3fa5d25de16a919c3dc3adc6085447efcb880108) [codex] harden heartbeat run summaries and recovery context (#3742)
- [`7463479`](https://github.com/paperclipai/paperclip/commit/7463479fc82904fd1965ba21ad9059195963e406) fix: disable HTTP caching on run log endpoints (#3724)

---

💬 **Reviewer:** comment `@gardener fix` after leaving feedback.
gardener will read your review, push a fix, and reply.
(Or just leave a review — gardener auto-checks every 30 minutes.)