### PR TITLE
sync(paperclip-e392f6b1): Sync/master post pap1497 followups 2026 04 15 (from paperclipai/paperclip#3779)

### DIFF
--- a/drift/paperclip-e392f6b1/product/task-system/issue-filters/NODE.md
+++ b/drift/paperclip-e392f6b1/product/task-system/issue-filters/NODE.md
@@ -3,9 +3,15 @@ title: "Issue Filters"
 owners: [bingran-you, serenakeyitan, cryppadotta]
 ---
 
-Issue filters are a structured, composable query layer over the issues list, distinct from free-text Inbox search. They let users narrow the list by state, assignee, labels, and related dimensions from a single popover (`IssueFiltersPopover`), and the selected filters are reflected in the URL via the router so filtered views are shareable and reloadable.
+Issue filters are a structured, composable query layer over the issues list, distinct from free-text Inbox search. They let users narrow the list by state, priority, assignee, creator, labels, projects, and workspaces from a single popover (`IssueFiltersPopover`), plus an "hide routine executions" toggle when that capability is enabled.
 
-The filter model and its parsing/serialization live in `ui/src/lib/issue-filters.ts` (with `issue-filters.test.ts` as the contract). Treat this module as the single source of truth for how a filter set is represented, normalized, and round-tripped with the URL — UI components must not invent their own shapes. `IssuesList` and `Inbox`/`IssueDetail` pages consume the parsed filter state rather than raw query params.
+The filter model and its parsing/normalization live in `ui/src/lib/issue-filters.ts` (with `issue-filters.test.ts` as the contract). Treat this module as the single source of truth for how a filter set is represented and normalized — UI components must not invent their own shapes. `IssuesList` reads the normalized filter state through this module when constructing its view.
+
+Filter state persistence is local, not URL-based:
+
+- `IssuesList` persists its full view state — selected filters, quick-filter preset, column layout — to `localStorage` keyed per list instance, and rehydrates through `normalizeIssueFilterState` so legacy blobs are safe on read.
+- The `Issues` page only round-trips the free-text `q` search param (and an optional `participantAgentId`) in the URL. Structured filter selections are not part of the URL and are not shareable via link today.
+- `Inbox` keeps its own preference blob in `localStorage` (`ui/src/lib/inbox.ts`), separate from issue-list filter state.
 
 Keep Inbox search (keyword/substring matching across inbox items) conceptually separate from issue filters (structured predicates on issue fields). They can compose, but their models should not be merged — search narrows by text, filters narrow by facets.
 

--- a/drift/paperclip-e392f6b1/product/task-system/issue-filters/NODE.md
+++ b/drift/paperclip-e392f6b1/product/task-system/issue-filters/NODE.md
@@ -1,0 +1,12 @@
+---
+title: "Issue Filters"
+owners: [bingran-you, serenakeyitan, cryppadotta]
+---
+
+Issue filters are a structured, composable query layer over the issues list, distinct from free-text Inbox search. They let users narrow the list by state, assignee, labels, and related dimensions from a single popover (`IssueFiltersPopover`), and the selected filters are reflected in the URL via the router so filtered views are shareable and reloadable.
+
+The filter model and its parsing/serialization live in `ui/src/lib/issue-filters.ts` (with `issue-filters.test.ts` as the contract). Treat this module as the single source of truth for how a filter set is represented, normalized, and round-tripped with the URL — UI components must not invent their own shapes. `IssuesList` and `Inbox`/`IssueDetail` pages consume the parsed filter state rather than raw query params.
+
+Keep Inbox search (keyword/substring matching across inbox items) conceptually separate from issue filters (structured predicates on issue fields). They can compose, but their models should not be merged — search narrows by text, filters narrow by facets.
+
+When adding a new filter dimension: extend the schema in `issue-filters.ts`, add a round-trip test in `issue-filters.test.ts`, surface the control in `IssueFiltersPopover`, and make sure any service-side counterpart in `server/src/services/issues.ts` / `server/src/routes/issues.ts` accepts the same shape so the client and server agree on filter semantics.

--- a/drift/paperclip-e392f6b1/product/task-system/issue-references/NODE.md
+++ b/drift/paperclip-e392f6b1/product/task-system/issue-references/NODE.md
@@ -1,0 +1,10 @@
+---
+title: "Issue References"
+owners: [bingran-you, serenakeyitan, cryppadotta]
+---
+
+Issue references are the canonical way the UI names and links to issues from free-form text and structured fields. The parsing and formatting rules live in `ui/src/lib/issue-reference.ts` (covered by `issue-reference.test.ts`) and are shared by the Inbox list, the issues list, and the issue detail view so that a reference means the same thing everywhere it appears.
+
+Treat `issue-reference.ts` as the single entry point: components should not hand-roll regexes or string templates for issue IDs. This keeps display, linking, and comparison consistent as the reference format evolves (e.g. adding company or project prefixes) and makes it safe to change the surface format in one place.
+
+When an issue reference resolves to an in-app route, it should go through `ui/src/lib/router.tsx` rather than a bare `<a>` so navigation stays within the SPA and preserves filter/search state. Pair any new reference shape with a test in `issue-reference.test.ts` before wiring it into components.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 5d1ed71..b8725c5
- Proposal files: 2

Proposals:
- TREE_MISS: drift/paperclip-e392f6b1/product/task-system/issue-filters/NODE.md — This PR introduces a structured issue filters system (IssueFiltersPopover, issue-filters lib with tests) that no existing inbox-search, issue-list-ux, or task-system node covers as a persisted, URL-addressable filter model.
- TREE_MISS: drift/paperclip-e392f6b1/product/task-system/issue-references/NODE.md — The PR adds a dedicated issue-reference parsing/formatting module (ui/src/lib/issue-reference.ts + tests) used across Inbox and IssueDetail; no existing node captures how issue references are recognized and rendered.

Commits:
- [`6e6f538`](https://github.com/paperclipai/paperclip/commit/6e6f5386302045e7df5598cc16705f0e7b0ef76f) [codex] Improve issue detail and issue-list UX (#3678)
- [`e890761`](https://github.com/paperclipai/paperclip/commit/e89076148a577e1b279d0191c7699011488433ce) [codex] Improve workspace runtime and navigation ergonomics (#3680)
- [`7f893ac`](https://github.com/paperclipai/paperclip/commit/7f893ac4ec9f700efaf902be8a57ce510c1c7092) [codex] Harden execution reliability and heartbeat tooling (#3679)
- [`213bcd8`](https://github.com/paperclipai/paperclip/commit/213bcd8c7ab8e4a3839852ff7bd14f4383fc0bac) fix: include routine-execution issues in agent inbox-lite (#3329)
- [`d0a8d4e`](https://github.com/paperclipai/paperclip/commit/d0a8d4e08a5a7d55e0ade6c4906830ae5699b9cb) fix(routines): include cronExpression and timezone in list trigger response (#3209)
- [`b816809`](https://github.com/paperclipai/paperclip/commit/b816809a1e84a2ed7a8fc57fa0223a61814f147d) fix(server): respect externally set PAPERCLIP_API_URL env var (#3472)
- [`f6ce976`](https://github.com/paperclipai/paperclip/commit/f6ce9765449db5ebcf1497530379eb87f135ce81) fix: Anthropic subscription quota always shows 100% used (#3589)
- [`50cd76d`](https://github.com/paperclipai/paperclip/commit/50cd76d8a3f2fc06d1a5af63840abd3d7a1bcd02) feat(adapters): add capability flags to ServerAdapterModule (#3540)
- [`32a9165`](https://github.com/paperclipai/paperclip/commit/32a9165ddf6308f3b46eae0653b6f583e502e538) [codex] harden authenticated routes and issue editor reliability (#3741)
- [`f460f74`](https://github.com/paperclipai/paperclip/commit/f460f744eff5832dc38dc89eb131e3becb229e61) fix: trust PAPERCLIP_PUBLIC_URL in board mutation guard (#3731)
- [`6059c66`](https://github.com/paperclipai/paperclip/commit/6059c665d5ef72e11198981d54cf038a8368c0a6) fix(a11y): remove maximum-scale and user-scalable=no from viewport (#3726)
- [`0d87fd9`](https://github.com/paperclipai/paperclip/commit/0d87fd9a11e4c6d732e8695ece13ddc69b4a6265) fix: proper cache headers for static assets and SPA fallback (#3734)
- [`3905027`](https://github.com/paperclipai/paperclip/commit/390502736c320d6fbeb3f789f52a210a1dfc4a45) chore(ui): drop console.* and legal comments in production builds (#3728)
- [`c1a0249`](https://github.com/paperclipai/paperclip/commit/c1a02497b0a593b35364aa16452bec97d3b86ad9) [codex] fix worktree dev dependency ergonomics (#3743)
- [`3fa5d25`](https://github.com/paperclipai/paperclip/commit/3fa5d25de16a919c3dc3adc6085447efcb880108) [codex] harden heartbeat run summaries and recovery context (#3742)
- [`7463479`](https://github.com/paperclipai/paperclip/commit/7463479fc82904fd1965ba21ad9059195963e406) fix: disable HTTP caching on run log endpoints (#3724)
- [`d4c3899`](https://github.com/paperclipai/paperclip/commit/d4c3899ca4c9c2abfbcbeab8056a9036f30daf34) [codex] improve issue and routine UI responsiveness (#3744)
- [`5f45712`](https://github.com/paperclipai/paperclip/commit/5f457128463cbdc9d2282dacb3dfa44bc99fceb1) Sync/master post pap1497 followups 2026 04 15 (#3779)
- [`b8725c5`](https://github.com/paperclipai/paperclip/commit/b8725c52eff66cdea8cb223f1ca885475a254468) release: v2026.416.0 notes (#3782)

---

💬 **Reviewer:** comment `@gardener fix` after leaving feedback.
gardener will read your review, push a fix, and reply.
(Or just leave a review — gardener auto-checks every 30 minutes.)