### PR TITLE
fix(product): update company model to reflect multi-operator access (V1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,9 +29,13 @@
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi
+/engineering/backend/webhook-signing-modes/        @bingran-you @cryppadotta @serenakeyitan @antonio-mello-ai
 /engineering/cli/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/cli/cli-mirrors-api-and-instance-ops.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/contributor-guide/                    @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/company-scoped-isolation.md  @bingran-you @cryppadotta @serenakeyitan
 /engineering/execution-workspaces/                 @bingran-you @cryppadotta @serenakeyitan
@@ -39,10 +43,14 @@
 /engineering/frontend/api-layer-and-react-query-over-global-state.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/inbox-list/                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-document-freshness/    @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/issue-list-ux/               @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-thread-ux/             @bingran-you @cryppadotta @serenakeyitan
+/engineering/mcp/                                  @bingran-you @cryppadotta @serenakeyitan
+/engineering/mcp-server/                           @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/                               @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/const-arrays-and-zero-runtime-dependencies.md @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/                                   @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/backups/                           @bingran-you @cryppadotta @serenakeyitan @aronprins
 /infrastructure/ci-cd/                             @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/ci-cd/ci-owns-the-lockfile.md      @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/                        @bingran-you @cryppadotta @serenakeyitan
@@ -51,6 +59,8 @@
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan
+/members/antonio-mello-ai/                         @antonio-mello-ai
+/members/aronprins/                                @aronprins
 /members/bingran-you/                              @bingran-you
 /members/devinfoley/                               @devinfoley
 /members/dotta/                                    @cryppadotta
@@ -72,9 +82,14 @@
 /product/company-model/company-is-the-top-level-boundary.md @bingran-you @cryppadotta @serenakeyitan
 /product/governance/                               @bingran-you @cryppadotta @serenakeyitan
 /product/governance/server-enforced-approvals-and-budget-stops.md @bingran-you @cryppadotta @serenakeyitan
+/product/governance/issue-approvals/               @bingran-you @cryppadotta @serenakeyitan
+/product/routines/                                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/auto-checkout/                @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/comment-wake/                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/inbox-search/                 @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/issue-blockers/               @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-thread-ux/              @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/vscode-task-interoperability/ @bingran-you @cryppadotta @serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/product/NODE.md
+++ b/product/NODE.md
@@ -20,7 +20,7 @@ One Paperclip instance runs multiple **Companies**. Each Company has a **goal**,
 
 1. **Control plane, not execution plane.** Paperclip never runs agent code directly. Agents run wherever they run (local processes, cloud services, third-party platforms) and report into the control plane via adapters.
 
-2. **Company is the unit of organization.** Everything is company-scoped. Multi-tenancy is one operator running multiple companies, not multiple operators sharing a deployment.
+2. **Company is the unit of organization.** Everything is company-scoped. Multiple human operators can share a deployment (with real identities, invite flows, and company-scoped membership), but the deployment is still scoped to one organization — not shared across unrelated orgs.
 
 3. **Tasks are the communication channel.** No separate chat or messaging system. All agent communication flows through tasks and comments, keeping context attached to work and creating a natural audit trail.
 
@@ -32,13 +32,13 @@ One Paperclip instance runs multiple **Companies**. Each Company has a **goal**,
 
 7. **Progressive disclosure.** Top layer: human-readable summary. Middle layer: checklist/steps/artifacts. Bottom layer: raw logs/tool calls/transcript.
 
-8. **Local-first, cloud-ready.** The mental model should not change between local solo use and shared/cloud deployment. Two runtime modes: `local_trusted` (no login friction) and `authenticated` (session-based with private/public exposure).
+8. **Local-first, cloud-ready.** The mental model should not change between local solo use and shared/cloud deployment. Two runtime modes: `local_trusted` (no login friction, solo local use) and `authenticated` (session-based, supports multiple human operators with invite/membership flows and private/public hostname exposure).
 
 9. **Thin core, rich edges.** Knowledge bases, external revenue tracking, rich chat, and special surfaces go into plugins -- not the core control plane.
 
 ## V1 Scope Summary
 
-V1 demonstrates the full control-plane loop end-to-end: a human board creates a company, defines goals, hires agents into an org tree, agents receive and execute tasks via heartbeat invocations, costs are tracked with budget hard-stops, and the board can intervene anywhere. Success means one operator can run a small AI-native company with clear visibility and control.
+V1 demonstrates the full control-plane loop end-to-end: a human board creates a company, defines goals, hires agents into an org tree, agents receive and execute tasks via heartbeat invocations, costs are tracked with budget hard-stops, and the board can intervene anywhere. V1 also ships multi-operator access — multiple humans can share a deployment with real identities, invite flows, and company-scoped membership. Success means a small team of operators can run AI-native companies with clear visibility and control.
 
 **Explicitly deferred from V1:** plugin framework/SDK, knowledge base, revenue/expense accounting beyond tokens, public marketplace (ClipHub), multi-board governance, automatic self-healing orchestration.
 

--- a/product/company-model/NODE.md
+++ b/product/company-model/NODE.md
@@ -22,11 +22,17 @@ A Company's direction is defined by its set of **Initiatives** (the highest-leve
 
 **Rationale:** Real companies pursue multiple strategic objectives simultaneously. A single goal field would be too rigid; initiatives provide the needed flexibility while still anchoring all work to company direction.
 
-### Single-Tenant Deployment, Multi-Company Data Model
+### Single-Tenant Deployment, Multi-Operator Access
 
-Paperclip is not a SaaS. One deployment = one human operator's companies. Multi-company support is about one person running multiple AI businesses, not about sharing a platform across unrelated users.
+Paperclip is not a SaaS. One deployment = one organization's companies. Multiple human operators within that organization can share a deployment — with real identities, company membership, invite flows, and company-scoped access controls — but the deployment is still scoped to one org, not shared across unrelated users or organizations.
 
-**Rationale:** Single-tenancy eliminates an entire class of isolation, billing, and trust-boundary problems. The multi-company model lets power users run diverse AI businesses from one control plane.
+**Multi-operator access** is first-class: operators authenticate via session-based auth, join companies via invite links or join requests, hold roles (admin/member) with company-scoped grants, and see each other in the company member directory. This is "shared within one org", not generic multi-tenancy.
+
+**Runtime modes:**
+- `local_trusted` — no login friction, for solo local use where the operator trusts the environment
+- `authenticated` — session-based, supports multiple human operators with invite/membership flows and private/public hostname exposure
+
+**Rationale:** The move from single-operator to multi-operator does not require SaaS-style cross-org isolation. Keeping deployment-scoped tenancy eliminates billing and cross-org trust-boundary complexity while enabling real team use. Company-scoping remains the isolation unit — operators access only companies they are members of.
 
 ### Company Lifecycle
 

--- a/product/company-model/company-is-the-top-level-boundary.md
+++ b/product/company-model/company-is-the-top-level-boundary.md
@@ -28,8 +28,9 @@ model would introduce in V1.
   company level before going deeper.
 - Import/export and portability features should preserve the company as the
   stable package boundary.
-- Deployment-level multi-company support exists for one operator running
-  multiple businesses, not for unrelated operators sharing an instance.
+- Deployment-level multi-company support exists for one organization's operators
+  running multiple businesses, not for unrelated organizations sharing an instance.
+  Multiple human operators within the same org can share a deployment via invite/membership flows.
 
 ## Related Domains
 

--- a/product/governance/NODE.md
+++ b/product/governance/NODE.md
@@ -12,9 +12,9 @@ Board powers, approval gates, budget controls, and cost tracking -- the human ov
 
 ### Single Human Board (V1)
 
-Every Company has a Board that governs high-impact decisions. V1: one human operator per deployment. The Board is not just an approval gate -- it is a live control surface. The human can intervene at any level at any time.
+Every Company has a Board that governs high-impact decisions. V1 supports multiple human operators per deployment (via invite/membership flows), but multi-member Board governance, delegated authority, and per-member hiring budgets are deferred — the Board acts as a unified control surface for now. The human can intervene at any level at any time.
 
-**Rationale:** Conservative default. Human control is non-negotiable for V1. Multi-member boards, delegated authority, and hiring budgets are deferred to avoid premature complexity in the governance model.
+**Rationale:** Conservative default. Human control is non-negotiable for V1. Multi-member board governance and delegated authority are deferred to avoid premature complexity, even though the deployment now supports multiple authenticated operators.
 
 ### Board Powers (Always Available)
 


### PR DESCRIPTION
## What

Updates 4 product nodes to reflect that multi-operator access is now first-class in V1.

## Why

PR paperclipai/paperclip#3784 shipped collaborative multi-operator invite flows, but the tree still said \"one deployment = one human operator\". This caused gardener to flag #3784 as \`NEEDS_REVIEW\` correctly per the tree — but the maintainer merged it cleanly, making it a wrong call on the bench (scored as false alarm).

Root cause: the tree was outdated, not gardener. Fix = update the tree.

## End-to-end test

Before opening this PR, all nodes referencing \"single-tenant\", \"one operator\", \"one human operator\", and related terms were scanned. Four files needed updating:

1. \`product/company-model/NODE.md\` — renamed decision to \"Multi-Operator Access\", describes invite/membership flows and two runtime modes explicitly
2. \`product/NODE.md\` — decisions #2 and #8 updated; V1 scope summary updated
3. \`product/governance/NODE.md\` — \"V1: one human operator per deployment\" was stale; clarified that multiple operators are supported but multi-member Board governance is still deferred
4. \`product/company-model/company-is-the-top-level-boundary.md\` — updated implication bullet to reflect org-scoped multi-operator deployment

## What stays the same

- Still deployment-scoped (not SaaS multi-tenant across unrelated orgs)
- Company-scoping remains the isolation unit
- \`local_trusted\` mode is unchanged
- Multi-member Board governance, delegated authority, hiring budgets — still deferred

## Related

- Merge conflict issues filed: agent-team-foundation/first-tree#188, agent-team-foundation/repo-gardener#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)