### PR TITLE
ci: update workflows for first-tree 0.2.9 namespaced CLI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,9 +29,13 @@
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi
+/engineering/backend/webhook-signing-modes/        @bingran-you @cryppadotta @serenakeyitan @antonio-mello-ai
 /engineering/cli/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/cli/cli-mirrors-api-and-instance-ops.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/contributor-guide/                    @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/database/company-scoped-isolation.md  @bingran-you @cryppadotta @serenakeyitan
 /engineering/execution-workspaces/                 @bingran-you @cryppadotta @serenakeyitan
@@ -39,10 +43,14 @@
 /engineering/frontend/api-layer-and-react-query-over-global-state.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/inbox-list/                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-document-freshness/    @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/issue-list-ux/               @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-thread-ux/             @bingran-you @cryppadotta @serenakeyitan
+/engineering/mcp/                                  @bingran-you @cryppadotta @serenakeyitan
+/engineering/mcp-server/                           @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/                               @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/const-arrays-and-zero-runtime-dependencies.md @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/                                   @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/backups/                           @bingran-you @cryppadotta @serenakeyitan @aronprins
 /infrastructure/ci-cd/                             @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/ci-cd/ci-owns-the-lockfile.md      @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/                        @bingran-you @cryppadotta @serenakeyitan
@@ -51,6 +59,8 @@
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan
+/members/antonio-mello-ai/                         @antonio-mello-ai
+/members/aronprins/                                @aronprins
 /members/bingran-you/                              @bingran-you
 /members/devinfoley/                               @devinfoley
 /members/dotta/                                    @cryppadotta
@@ -72,9 +82,14 @@
 /product/company-model/company-is-the-top-level-boundary.md @bingran-you @cryppadotta @serenakeyitan
 /product/governance/                               @bingran-you @cryppadotta @serenakeyitan
 /product/governance/server-enforced-approvals-and-budget-stops.md @bingran-you @cryppadotta @serenakeyitan
+/product/governance/issue-approvals/               @bingran-you @cryppadotta @serenakeyitan
+/product/routines/                                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/auto-checkout/                @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/comment-wake/                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/inbox-search/                 @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/issue-blockers/               @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-thread-ux/              @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/vscode-task-interoperability/ @bingran-you @cryppadotta @serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npx -p first-tree first-tree generate-codeowners
+      - run: npx -p first-tree first-tree tree generate-codeowners
 
       - name: Commit if changed
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: "22"
 
       - name: Validate tree
-        run: npx -p first-tree first-tree verify
+        run: npx -p first-tree first-tree tree verify


### PR DESCRIPTION
## Summary

- `validate.yml`: `first-tree verify` → `first-tree tree verify`
- `codeowners.yml`: `first-tree generate-codeowners` → `first-tree tree generate-codeowners`

Refs #316

## Why

`first-tree@0.2.9` moved these commands under the `tree` product namespace. Every PR in this repo (including main) has failed CI since the upgrade with:

```
Unknown first-tree namespace: verify
Unknown first-tree namespace: generate-codeowners
```

This is the minimal fix — the change that makes CI green again matches the exact command suggestion first-tree prints in the error message.

## Test plan

- [ ] `validate` check passes on this PR
- [ ] `update` check passes on this PR