### PR TITLE
engineering/frontend: add dynamic-adapter-parser-sandbox node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@
 /engineering/execution-workspaces/                 @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/api-layer-and-react-query-over-global-state.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/dynamic-adapter-parser-sandbox/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/inbox-list/                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-document-freshness/    @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-list-ux/               @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/frontend/NODE.md
+++ b/engineering/frontend/NODE.md
@@ -58,3 +58,4 @@ Pages live in `/ui/src/pages/` and map to top-level routes:
 ## Decision Records
 
 - [api-layer-and-react-query-over-global-state.md](api-layer-and-react-query-over-global-state.md) — Why frontend data flow is organized around a shared API layer plus React Query instead of a global store.
+- [dynamic-adapter-parser-sandbox/](dynamic-adapter-parser-sandbox/NODE.md) — Web Worker sandbox that executes third-party adapter `ui-parser.js` with network/escape-hatch APIs shadowed, plus the async-to-sync cached-result protocol.

--- a/engineering/frontend/dynamic-adapter-parser-sandbox/NODE.md
+++ b/engineering/frontend/dynamic-adapter-parser-sandbox/NODE.md
@@ -1,0 +1,17 @@
+---
+title: "Dynamic Adapter Parser Sandbox"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/frontend", "adapters"]
+---
+
+# Dynamic Adapter Parser Sandbox
+
+External adapters can ship a `dist/ui-parser.js` that the Paperclip UI fetches from `/api/adapters/:type/ui-parser.js` to turn stdout lines into `TranscriptEntry[]`. Because this code is third-party and runs in the browser, it is executed inside a **dedicated Web Worker sandbox** rather than evaluated on the main thread. The worker is spawned from an inline Blob URL — no extra file is served — and communicates with the UI through a narrow postMessage protocol.
+
+## Security boundary
+
+The worker bootstrap runs in strict mode and shadows dangerous globals with `undefined` or no-ops before evaluating the parser source. This explicitly disables network and escape-hatch APIs: `fetch`, `XMLHttpRequest`, `WebSocket`, `EventSource`, `importScripts`, `navigator.sendBeacon`, child `Worker`/`SharedWorker`, `Blob`, `RTCPeerConnection`/`RTCDataChannel`, and `URL.createObjectURL` / `revokeObjectURL`. The intent is that a malicious or buggy parser cannot reach the board UI's same-origin state (cookies, localStorage, DOM, authenticated fetch) nor open side channels out of the worker.
+
+## Protocol and sync fast-path
+
+Messages are: `init { source }` → `ready | error`, then `parse { id, line, ts }` → `result { id, entries }`. Because postMessage is async but the existing `parseStdoutLine` contract is synchronous, completed worker results are cached and the adapter registry is notified via `setDynamicParserResultNotifier` to recompute transcripts when new results arrive. In practice this adds roughly one frame of latency, which is imperceptible. The unused `parse_batch` branch is intentionally excluded from the bootstrap, and tests in `sandboxed-parser-worker.test.ts` assert the lockdown strings and strict-mode wrapper are present.


### PR DESCRIPTION
Adds `engineering/frontend/dynamic-adapter-parser-sandbox/NODE.md` capturing the Web Worker sandbox introduced in paperclipai/paperclip#4225 for executing third-party adapter `ui-parser.js`.

## Why this belongs on the tree

This is a cross-cutting security architecture decision (what we shadow, why, and how the async protocol reconciles with the sync `parseStdoutLine` contract) that future agents touching either the frontend or adapter contracts need to know about before making changes. It's not derivable from reading the code — it's the *why* behind the lockdown list and the cached-notifier pattern.

## Contents

- Security boundary: strict-mode worker, explicit global shadowing list (`fetch`, `XMLHttpRequest`, `WebSocket`, `EventSource`, `importScripts`, `sendBeacon`, child `Worker`/`SharedWorker`, `Blob`, `RTCPeerConnection`/`RTCDataChannel`, `URL.createObjectURL`/`revokeObjectURL`), and the threat model (same-origin state + side channels).
- Protocol: `init`/`ready`/`error` + `parse`/`result`; cached-results + `setDynamicParserResultNotifier` to keep the synchronous parse API.
- Testing note: `sandboxed-parser-worker.test.ts` asserts lockdown strings and the strict-mode wrapper.

Also adds a pointer from the parent `engineering/frontend/NODE.md` Decision Records section.

Closes #320 · gardener proposal `81057b7e1a17` · source: paperclipai/paperclip#4225 (merged).

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
