### PR TITLE
tree: add issue-workspace-runtime-tools node under mcp-server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@
 /engineering/frontend/issue-thread-ux/             @bingran-you @cryppadotta @serenakeyitan
 /engineering/mcp/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/mcp-server/                           @bingran-you @cryppadotta @serenakeyitan
+/engineering/mcp-server/issue-workspace-runtime-tools/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/                               @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/const-arrays-and-zero-runtime-dependencies.md @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/                                   @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/mcp-server/NODE.md
+++ b/engineering/mcp-server/NODE.md
@@ -37,6 +37,10 @@ The MCP server ships a broad initial surface covering the core Paperclip domain 
 
 **Escape hatch:** `paperclipApiRequest` — limited to paths under `/api` with JSON bodies, for endpoints without a dedicated MCP tool yet.
 
+## Sub-domains
+
+- **[issue-workspace-runtime-tools/](issue-workspace-runtime-tools/NODE.md)** — MCP tools for inspecting and controlling runtime services attached to an issue workspace (get runtime, wait for service, start/stop/restart).
+
 ## Relationships
 
 - Depends on backend service layer (`engineering/backend/`)

--- a/engineering/mcp-server/issue-workspace-runtime-tools/NODE.md
+++ b/engineering/mcp-server/issue-workspace-runtime-tools/NODE.md
@@ -1,0 +1,34 @@
+---
+title: "Issue Workspace Runtime MCP Tools"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/mcp-server/NODE.md", "engineering/backend/NODE.md", "product/task-system/NODE.md"]
+---
+
+# Issue Workspace Runtime MCP Tools
+
+The MCP server exposes tools for inspecting and controlling the runtime services attached to an issue workspace, so agents can start, wait on, and query long-running services (e.g. dev servers) without leaving the MCP interface.
+
+## Key Decisions
+
+### Read Tools
+
+- `paperclipGetIssueWorkspaceRuntime` returns the current runtime state of an issue workspace (which services are declared, their current status, last transition).
+- `paperclipWaitForIssueWorkspaceService` blocks until a named service reaches a ready state, so agents can sequence actions that depend on a service being up (e.g. wait for a dev server before running smoke tests).
+
+### Write Tool
+
+`paperclipControlIssueWorkspaceServices` mutates service state (start / stop / restart) for the issue workspace. It is the single control-plane entry point for workspace services via MCP — other mutations flow through existing issue, comment, or approval tools.
+
+### Scope
+
+These tools are scoped to a specific issue workspace and respect the same company/actor authorization as other MCP issue tools. They do not replace the HTTP or CLI control-plane paths; they expose the same backend service layer to MCP clients.
+
+## Relationships
+
+- Extends the MCP tool surface defined in the parent [mcp-server/NODE.md](../NODE.md).
+- Backed by the workspace runtime services in `engineering/backend/` (issue checkout + service lifecycle).
+- Intended for agent runtimes that drive long-running issue workspaces — see `product/task-system/` for the issue-workspace lifecycle.
+
+## Source
+
+Introduced in [paperclipai/paperclip#4223 — "Harden heartbeat scheduling and runtime controls"](https://github.com/paperclipai/paperclip/pull/4223).


### PR DESCRIPTION
Addresses #325.

Adds `engineering/mcp-server/issue-workspace-runtime-tools/NODE.md` to capture the new MCP capability surface introduced by [paperclipai/paperclip#4223](https://github.com/paperclipai/paperclip/pull/4223) — *Harden heartbeat scheduling and runtime controls*:

- `paperclipGetIssueWorkspaceRuntime` — read runtime state of an issue workspace.
- `paperclipWaitForIssueWorkspaceService` — block until a named service is ready.
- `paperclipControlIssueWorkspaceServices` — start / stop / restart workspace services.

Also links the new sub-domain from `engineering/mcp-server/NODE.md` so agents walking from the parent node can find it.

Rationale: this is a new control-plane surface for long-running workspace services exposed via MCP, which is a decision an agent needs to know about when designing workflows that depend on dev servers or other workspace services — it belongs on the tree, not just in the source README.

Node owners per parent NODE.md: @bingran-you @cryppadotta @serenakeyitan.

---
This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
