### PR TITLE
docs(engineering/backend): add heartbeat-scheduled-retry node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/heartbeat-scheduled-retry/    @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi
 /engineering/backend/webhook-signing-modes/        @bingran-you @cryppadotta @serenakeyitan @antonio-mello-ai
 /engineering/cli/                                  @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -68,6 +68,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 
 - [dev-runner/](dev-runner/) — Local development runner and worktree dev tooling
 - [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
+- [heartbeat-scheduled-retry/](heartbeat-scheduled-retry/) — Scheduled-retry path for transient upstream failures, layered on the run lifecycle
 - [static-asset-serving/](static-asset-serving/) — Static asset cache headers and SPA fallback routing
 
 ## Decision Records

--- a/engineering/backend/heartbeat-run-orchestration/NODE.md
+++ b/engineering/backend/heartbeat-run-orchestration/NODE.md
@@ -1,6 +1,7 @@
 ---
 title: "Heartbeat Run Orchestration"
 owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/backend/heartbeat-scheduled-retry/NODE.md"]
 ---
 
 # Heartbeat Run Orchestration

--- a/engineering/backend/heartbeat-scheduled-retry/NODE.md
+++ b/engineering/backend/heartbeat-scheduled-retry/NODE.md
@@ -1,0 +1,42 @@
+---
+title: "Heartbeat Scheduled Retry"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/backend/heartbeat-run-orchestration/NODE.md", "adapters/codex-local/NODE.md"]
+---
+
+# Heartbeat Scheduled Retry
+
+Scheduled-retry path for heartbeat runs that fail with transient upstream conditions. Distinct from process-loss recovery: instead of terminating a run on failure, the orchestrator can re-queue it for a future attempt.
+
+**Source:** `server/src/services/heartbeat*` (scheduler + retry classification), `adapters/codex-local` (transient classifier and fallback modes), `heartbeat_runs` table.
+
+---
+
+## Key Decisions
+
+### Retry State Lives on the Run Row
+
+The `heartbeat_runs` table carries `scheduled_retry_at`, `scheduled_retry_attempt`, and `scheduled_retry_reason`. Retry intent is durable on the run itself rather than tracked out-of-band in a separate queue. The scheduler reads these fields to decide when to wake the run again, and the reason column makes the cause auditable from the run alone.
+
+### Transient Upstream Classification Gates Retries
+
+Automatic retries only fire when an execution failure matches a known transient upstream shape. The Codex adapter's `isCodexTransientUpstreamError` helper is the gate: it currently recognizes the remote-compaction "high demand / temporary errors" signal and similar shapes. Deterministic errors (e.g. invalid-parameter responses, account rate limits) fall through to normal failure handling so we don't mask user-actionable problems behind silent retries.
+
+### Fallback Modes Trade Continuity for Resilience
+
+When a retry is scheduled, the adapter can switch invocation shape via `codexTransientFallbackMode`:
+
+- `same_session` — retry with the same session id (cheapest, preserves context).
+- `safer_invocation` — same session, more conservative invocation flags.
+- `fresh_session` — drop session continuity to escape a poisoned conversation.
+- `fresh_session_safer_invocation` — both, for the hardest cases.
+
+Successive attempts can escalate through these modes so a transient failure that doesn't clear with a plain retry still has a path to success.
+
+---
+
+## Boundaries
+
+- **Run lifecycle and process-loss recovery** are owned by [heartbeat-run-orchestration](../heartbeat-run-orchestration/NODE.md). This node only covers the scheduled-retry path layered on top of that lifecycle.
+- **Adapter-specific transient classification** lives in each adapter (today: `adapters/codex-local`). The orchestrator decides *whether* to retry based on the adapter's signal; it does not own the per-adapter error taxonomy.
+- **Account-level rate limiting and quota policy** are explicitly out of scope — those should surface as failures to the operator, not be masked by retries.


### PR DESCRIPTION
Closes #322.

Drafts the new `engineering/backend/heartbeat-scheduled-retry/NODE.md` proposed by `first-tree gardener` from source PR paperclipai/paperclip#4223 (`[codex] Harden heartbeat scheduling and runtime controls`).

## Scope
- New node captures three decisions: durable retry state on the `heartbeat_runs` row (`scheduled_retry_at` / `_attempt` / `_reason`), the `isCodexTransientUpstreamError` classifier as the retry gate, and the `codexTransientFallbackMode` escalation ladder.
- Boundaries call out what stays in `engineering/backend/heartbeat-run-orchestration` (lifecycle + process-loss recovery) and what stays in adapters (per-adapter error taxonomy).
- Parent `engineering/backend/NODE.md` lists the new sub-domain; `heartbeat-run-orchestration/NODE.md` gets a reciprocal `soft_links` entry.

## Owner review
Owners listed on the new node match the parent (`bingran-you`, `cryppadotta`, `serenakeyitan`). Please push back if the scope or fallback-mode summary doesn't match the PR's intent.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
