### PR TITLE
gardener: blocked issue composer + reopen on reassignment (#321)

### DIFF
--- a/product/task-system/issue-blockers/NODE.md
+++ b/product/task-system/issue-blockers/NODE.md
@@ -31,11 +31,13 @@ When an issue is blocked, the issue thread renders the unresolved blocker summar
 
 **Rationale:** The cost of a blocked contribution (a comment that ignores the blocker, a handoff to an agent who cannot make progress) is high. Surfacing blockers at the point of action is a small UX change with outsized coordination value.
 
-### Blocked Resumes to Todo on Agent Reassignment
+### Issue Thread Treats Blocked as Resumable on Agent Reassignment
 
-Reassigning an agent via a comment implicitly reopens issues whose status is `done`, `cancelled`, **or** `blocked`. Previously only terminal states (`done`, `cancelled`) triggered implicit reopen; `blocked` is now treated as a resumable state because a fresh agent assignment is a strong signal that the blocker condition should be retested rather than left dormant.
+In the issue chat thread, a comment that reassigns to an agent is treated as an implicit reopen when the issue status is `done`, `cancelled`, **or** `blocked`. Previously only the terminal states (`done`, `cancelled`) triggered implicit reopen in the composer; `blocked` is now treated as a resumable state in this flow because a fresh agent assignment is a strong signal that the blocker condition should be retested rather than left dormant.
 
-**Rationale:** A blocked issue can stay blocked long after its blocker is effectively resolved, either because the dependency wakeup was missed or because the blocker was resolved out-of-band (e.g., a workaround, a scope change). When an operator reassigns a new agent, they are asserting that the issue is worth pursuing again — the right default is to put it back in `todo` and let the new agent re-evaluate the block, not to leave it dormant.
+**Scope:** This is a UI / issue-thread decision, not a platform-level workflow invariant. The evidence in `paperclipai/paperclip#4224` is UI-side only — `ui/src/components/IssueChatThread.tsx` broadens `shouldImplicitlyReopenComment(...)`, and `ui/src/lib/optimistic-issue-comments.ts` broadens `applyOptimisticIssueCommentUpdate(...)` so the optimistic view reflects the same resume rule. The server-side task-system source of truth for whether reassignment of a blocked issue persistently reopens to `todo` is not established by that PR; if and when the server-side rule is added, this decision should be promoted and this node updated to cite that source.
+
+**Rationale:** A blocked issue can stay blocked long after its blocker is effectively resolved, either because the dependency wakeup was missed or because the blocker was resolved out-of-band (e.g., a workaround, a scope change). When an operator reassigns a new agent from the issue thread, they are asserting that the issue is worth pursuing again — the right composer default is to put it back in `todo` optimistically and let the new agent re-evaluate the block, not to leave it dormant in the thread.
 
 ## Relationship to Issue Links
 

--- a/product/task-system/issue-blockers/NODE.md
+++ b/product/task-system/issue-blockers/NODE.md
@@ -25,6 +25,18 @@ When **all** of a dependent issue's blockers transition to `done`, the system fi
 
 Dependency wakeups use the same wake event infrastructure as other agent wake triggers (e.g., comment mentions, assignment changes). The wake event is scoped to the unblocked issue, enabling auto-checkout on wake to function correctly.
 
+### Blocker Context Lives Next to the Composer
+
+When an issue is blocked, the issue thread renders the unresolved blocker summary inline with the composer, not only in the properties panel. The composer is where the next action happens — a new comment, a handoff, a reassignment — so the blocker list is placed where it will actually inform that action. Putting it only in the properties panel would require agents and humans to deliberately scan for it before contributing, and many would not.
+
+**Rationale:** The cost of a blocked contribution (a comment that ignores the blocker, a handoff to an agent who cannot make progress) is high. Surfacing blockers at the point of action is a small UX change with outsized coordination value.
+
+### Blocked Resumes to Todo on Agent Reassignment
+
+Reassigning an agent via a comment implicitly reopens issues whose status is `done`, `cancelled`, **or** `blocked`. Previously only terminal states (`done`, `cancelled`) triggered implicit reopen; `blocked` is now treated as a resumable state because a fresh agent assignment is a strong signal that the blocker condition should be retested rather than left dormant.
+
+**Rationale:** A blocked issue can stay blocked long after its blocker is effectively resolved, either because the dependency wakeup was missed or because the blocker was resolved out-of-band (e.g., a workaround, a scope change). When an operator reassigns a new agent, they are asserting that the issue is worth pursuing again — the right default is to put it back in `todo` and let the new agent re-evaluate the block, not to leave it dormant.
+
 ## Relationship to Issue Links
 
 Blocker relationships build on the issue link infrastructure but add behavioral semantics. The drift node at `drift/paperclip-e392f6b1/product/task-system/issue-links/` captured the open questions around link types — this node resolves the blocker/dependency subset of those questions.


### PR DESCRIPTION
## Summary

Addresses gardener sync proposal #321 from paperclipai/paperclip#4224.

Adds two new key decisions to `product/task-system/issue-blockers/NODE.md`:

- **Blocker context lives next to the composer** — the blocked-by summary renders inline with the issue-thread composer, not only in the properties panel, so it informs the next comment / handoff / reassignment.
- **Blocked resumes to `todo` on agent reassignment** — reassigning via a comment now implicitly reopens `blocked` issues (alongside the existing `done` and `cancelled` cases), since a fresh assignment is a strong signal the blocker should be retested rather than left dormant.

Both decisions slot naturally into the existing issue-blockers node — they extend its behavioral contract with UX and lifecycle rules rather than describing a new subsystem, so a new node would have been over-structured.

## Owner review

cc @bingran-you @cryppadotta @serenakeyitan — per `NODE.md` frontmatter.

Closes #321

---

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
