### PR TITLE
docs(task-system): add Stale Execution Lock Recovery node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,5 +95,6 @@
 /product/task-system/issue-references/             @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-thread-interactions/    @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-thread-ux/              @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/stale-execution-lock-recovery/ @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/vscode-task-interoperability/ @bingran-you @cryppadotta @serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/product/task-system/NODE.md
+++ b/product/task-system/NODE.md
@@ -72,6 +72,7 @@ Fixed, non-customizable: No priority (0), Urgent (1), High (2), Medium (3), Low 
 - **[dependency-blocked-interaction/](dependency-blocked-interaction/NODE.md)** — How blocked issues stay idle on deliverable work while still supporting human comment triage
 - **[issue-references/](issue-references/NODE.md)** — First-class mentions of issues inside other issues (PAP-123 style references, related-work summary)
 - **[issue-thread-interactions/](issue-thread-interactions/NODE.md)** — Structured interaction cards (suggest_tasks, ask_user_questions, request_confirmation) for soliciting explicit input inside issue threads
+- **[stale-execution-lock-recovery/](stale-execution-lock-recovery/NODE.md)** — Board-gated force-release and self-healing paths for stranded execution-run locks
 
 ## Open Questions
 

--- a/product/task-system/NODE.md
+++ b/product/task-system/NODE.md
@@ -52,11 +52,19 @@ Paperclip manages task-linked work artifacts: **issue documents** (rich-text pla
 
 **Rationale:** Agents need to produce visible outputs beyond status updates. Documents and attachments make work tangible without pulling Paperclip into build pipeline territory.
 
-### No Automatic Recovery
+### No Automatic Task Reassignment
 
-When an agent crashes mid-task, Paperclip does **not** auto-reassign or auto-release the task. Stale tasks (in `in_progress` with no recent activity) are surfaced through dashboards. Recovery is manual/explicit.
+When an agent crashes mid-task, Paperclip does **not** auto-reassign or auto-release the task itself. Stale tasks (in `in_progress` with no recent activity) are surfaced through dashboards, and reassignment is a manual/explicit decision.
 
-**Rationale:** Automatic recovery hides failures. Good visibility lets the right entity decide what to do. A project manager agent whose job is to monitor for stale work is the emergent pattern, not a built-in behavior.
+However, Paperclip *does* perform automatic cleanup of stale **execution locks** so that healthy runs can self-heal without stranding the issue. Specifically:
+
+- `clearExecutionRunIfTerminal` clears a stale `executionRunId` when the referenced run has reached a terminal state.
+- `adoptUnownedCheckoutRun` lets a live run adopt a checkout whose previous owner is gone.
+- Unrecoverable cases are resolved by a board-gated, fully audited `POST /issues/:issueId/admin/force-release`.
+
+See [stale-execution-lock-recovery/NODE.md](stale-execution-lock-recovery/NODE.md) for the full surface.
+
+**Rationale:** Automatic *task* recovery hides failures and removes the human/PM decision of what to do next, so we keep that manual. Automatic *lock* cleanup is a different problem: stale locks block otherwise-healthy runs with no useful signal for a human, so self-healing + an audited force-release escape hatch is the right trade-off. Task-level visibility stays intact; lock-level housekeeping doesn't need to.
 
 ### Priority Scale
 

--- a/product/task-system/stale-execution-lock-recovery/NODE.md
+++ b/product/task-system/stale-execution-lock-recovery/NODE.md
@@ -1,0 +1,44 @@
+---
+title: "Stale Execution Lock Recovery"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["product/task-system/NODE.md", "product/governance/NODE.md"]
+---
+
+# Stale Execution Lock Recovery
+
+Issues carry execution-run lock fields (`checkoutRunId`, `executionRunId`, `executionLockedAt`) that pair an in-progress issue with the harness run currently working it. When a harness crashes or a run terminates abnormally, these locks can get stranded and block further progress on the issue. Stale execution lock recovery is the set of behaviors that detect and resolve these strandings.
+
+This node refines the parent [Task System](../NODE.md) "No Automatic Recovery" decision: Paperclip still does not auto-reassign work, but it does expose explicit, audited recovery paths so operators and healthy runs can unstick an issue without bypassing governance.
+
+## Key Decisions
+
+### Board-Only Admin Force-Release
+
+A dedicated operator endpoint `POST /issues/:issueId/admin/force-release` clears stranded execution locks. It requires board access to the issue's company — this is a governance-sensitive recovery action, not a routine agent operation, because it overrides the normal checkout/release lifecycle. It optionally accepts `clearAssignee=true` to also detach the agent assignee when the agent itself is gone.
+
+**Rationale:** Force-release overrides the atomic checkout contract that the rest of the task system depends on. Gating it behind board access keeps the governance surface small and ensures the humans (or principals) accountable for the company are the ones who approve overrides.
+
+### Always Audit Force-Release
+
+Every force-release writes an `issue.admin_force_release` activity log entry including the previous `checkoutRunId` and `executionRunId`. Recovery actions bypass the normal locking contract, so the audit trail is the only record of what state was overwritten — it must always be present.
+
+**Rationale:** Without this log, a force-release is indistinguishable from a normal release, and there is no way to reconstruct which run was evicted or why. Aligned with the governance-first principle that every mutation has an audit trail.
+
+### Terminal-Run Auto-Clear and Orphan Adoption
+
+Alongside the manual operator path, the issue service exposes automatic recovery helpers:
+
+- `clearExecutionRunIfTerminal` clears lock fields when the referenced heartbeat run has reached a terminal state.
+- `adoptUnownedCheckoutRun` lets the rightful assignee agent re-claim an in-progress issue whose checkout lock has been cleared.
+
+These let healthy runs self-heal without requiring board intervention for every stale lock.
+
+**Rationale:** A terminated run cannot release its own lock, so trusting the heartbeat's terminal state is a safe, information-preserving signal. Orphan adoption keeps the single-assignee invariant intact while avoiding an operator ticket for every crashed run.
+
+## Why This Belongs on the Tree
+
+This is a governance-adjacent recovery surface that crosses the task-system, governance, and heartbeat-orchestration domains. Future agents designing features that touch issue checkout or execution runs must know this recovery path exists, that it is audited, and that the manual path is board-gated.
+
+## Source
+
+- paperclipai/paperclip#4258 — "[codex] Fix stale issue execution run locks" (introduced the operator endpoint, activity log entry, and auto-clear / adoption helpers)


### PR DESCRIPTION
## Summary

- Adds `product/task-system/stale-execution-lock-recovery/NODE.md` capturing the new operator recovery surface introduced in paperclipai/paperclip#4258.
- Registers the new sub-domain in the parent `product/task-system/NODE.md`.

Resolves #318 (gardener sync proposal `19aeb0ab73f4`).

### Key decisions captured

- **Board-Only Admin Force-Release** — `POST /issues/:issueId/admin/force-release` clears stranded execution locks; requires board access; optional `clearAssignee=true`.
- **Always Audit Force-Release** — every force-release writes an `issue.admin_force_release` activity log entry with previous `checkoutRunId` / `executionRunId`.
- **Terminal-Run Auto-Clear and Orphan Adoption** — `clearExecutionRunIfTerminal` + `adoptUnownedCheckoutRun` let healthy runs self-heal without board intervention.

Refines the parent "No Automatic Recovery" decision: still no auto-reassign, but explicit audited recovery paths now exist.

## Test plan

- [ ] Node owners (bingran-you, cryppadotta, serenakeyitan) confirm the decisions and rationale match the intent of paperclipai/paperclip#4258.
- [ ] `first-tree validate` (or equivalent tree CI) passes.

---

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
