### PR TITLE
product(agent-model): add max-concurrent-runs decision node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,6 +78,7 @@
 /product/                                          @bingran-you @cryppadotta @serenakeyitan
 /product/agent-model/                              @bingran-you @cryppadotta @serenakeyitan
 /product/agent-model/adapter-defined-agent-internals.md @bingran-you @cryppadotta @serenakeyitan
+/product/agent-model/max-concurrent-runs.md        @bingran-you @cryppadotta @serenakeyitan
 /product/company-model/                            @bingran-you @cryppadotta @serenakeyitan
 /product/company-model/company-is-the-top-level-boundary.md @bingran-you @cryppadotta @serenakeyitan
 /product/governance/                               @bingran-you @cryppadotta @serenakeyitan

--- a/product/agent-model/NODE.md
+++ b/product/agent-model/NODE.md
@@ -79,6 +79,7 @@ These are starting points and reference implementations, not mandated patterns.
 ## Decision Records
 
 - [adapter-defined-agent-internals.md](adapter-defined-agent-internals.md) — Why Paperclip owns control-plane agent fields while adapters own runtime-specific behavior.
+- [max-concurrent-runs.md](max-concurrent-runs.md) — Why new agents default to 5 concurrent heartbeat runs instead of V1's original 1.
 
 ## Agent Statuses
 

--- a/product/agent-model/max-concurrent-runs.md
+++ b/product/agent-model/max-concurrent-runs.md
@@ -1,0 +1,27 @@
+---
+title: "Agent Max Concurrent Runs"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["product/agent-model/NODE.md", "product/governance/NODE.md"]
+---
+
+# Agent Max Concurrent Runs
+
+Each agent has a `maxConcurrentRuns` setting on its heartbeat `runtimeConfig` that caps how many heartbeat runs the scheduler may have in flight simultaneously for that agent.
+
+## Key Decisions
+
+### New Agents Default to 5
+
+V1 originally fixed `maxConcurrentRuns` at `1` per agent. This was too restrictive in practice — agents frequently had useful parallelizable work (e.g., responding to a comment wake while a separate assignment run is still finishing). New agents now default to `5`, exported as `AGENT_DEFAULT_MAX_CONCURRENT_RUNS` from `@paperclipai/shared`.
+
+**Rationale:** Let agents overlap cheap work (comment wakes, reviews) with longer-running assignments without requiring an operator to hand-tune the field. 5 is conservative enough to keep adapter and cost blast radius bounded while unblocking common cases.
+
+### Applied to Imports and New Creations
+
+Company portability imports and new agent creation both populate `heartbeat.maxConcurrentRuns = 5` when the field is absent, keeping imported agents behaviorally consistent with freshly created ones.
+
+## Source
+
+- `packages/shared/src/constants.ts` — `AGENT_DEFAULT_MAX_CONCURRENT_RUNS`
+- `server/src/services/agents.ts`, `server/src/services/company-portability.ts`
+- `doc/SPEC-implementation.md` — scheduler spec


### PR DESCRIPTION
Closes #369.

Drafts the tree node proposed by `first-tree gardener` for `product/agent-model/max-concurrent-runs`, capturing the V1 governance change in paperclipai/paperclip#4086 where new agents now default to `AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 5` instead of the original `1`.

## Changes

- New leaf `product/agent-model/max-concurrent-runs.md` with proposed decision content, rationale, and source pointers.
- Linked from `product/agent-model/NODE.md` Decision Records.

Owners of `product/agent-model/` (`bingran-you`, `cryppadotta`, `serenakeyitan`), please review.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.