### PR TITLE
infrastructure: add discord-daily-digest node

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -p first-tree first-tree tree inject-context --skip-version-check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -p first-tree first-tree tree inject-context --skip-version-check",
+            "statusMessage": "Loading First Tree context"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 /infrastructure/deployment/                        @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/authenticated-docker-and-local-trusted-dev.md @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/deployment/bind-presets/           @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/discord-daily-digest/              @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan

--- a/infrastructure/NODE.md
+++ b/infrastructure/NODE.md
@@ -16,6 +16,7 @@ Deployment, Docker, CI/CD pipelines, testing strategy, and operational concerns 
 - **[ci-cd/](ci-cd/NODE.md)** -- GitHub Actions workflows, release pipeline, lockfile management.
 - **[testing/](testing/NODE.md)** -- Vitest unit tests, Playwright e2e, promptfoo evals, release smoke tests.
 - **[backups/](backups/NODE.md)** -- Automated database snapshots, compression, tiered retention, and backup configuration.
+- **[discord-daily-digest/](discord-daily-digest/NODE.md)** -- Daily merge digest posted from `master` to a Discord webhook by `scripts/discord-daily-digest.sh`.
 
 ---
 

--- a/infrastructure/discord-daily-digest/NODE.md
+++ b/infrastructure/discord-daily-digest/NODE.md
@@ -1,0 +1,17 @@
+---
+title: "Discord Daily Merge Digest"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["infrastructure/ci-cd/NODE.md"]
+---
+
+# Discord Daily Merge Digest
+
+`scripts/discord-daily-digest.sh` posts a summary of the previous day's merges on `master` to a Discord channel via an incoming webhook. It is intended to be run from a scheduled job (cron or CI) once per day.
+
+## Configuration
+
+The script requires a `DISCORD_WEBHOOK_URL` environment variable (documented in `.env.example`). It optionally takes a date argument in `YYYY-MM-DD` form; otherwise it defaults to today. Commit enumeration uses `git log --since/--until` against `master` and formats the payload as a Discord embed. Setting `DRY_RUN=1` prints the payload without posting, which is useful when wiring up a new schedule.
+
+## Related
+
+- CI scheduling for this kind of outbound notification belongs under [infrastructure/ci-cd/](../ci-cd/NODE.md). No scheduled workflow has been wired up in-repo yet — today the script must be invoked from an external cron or one-off CI dispatch.

--- a/infrastructure/discord-daily-digest/NODE.md
+++ b/infrastructure/discord-daily-digest/NODE.md
@@ -6,7 +6,7 @@ soft_links: ["infrastructure/ci-cd/NODE.md"]
 
 # Discord Daily Merge Digest
 
-`scripts/discord-daily-digest.sh` posts a summary of the previous day's merges on `master` to a Discord channel via an incoming webhook. It is intended to be run from a scheduled job (cron or CI) once per day.
+`scripts/discord-daily-digest.sh` posts a summary of the day's merges on `master` to a Discord channel via an incoming webhook. The script defaults to today; a scheduled job (cron or CI) typically invokes it once per day and may pass the prior day's date explicitly.
 
 ## Configuration
 


### PR DESCRIPTION
Adds `infrastructure/discord-daily-digest/NODE.md` to capture the daily merge digest script shipped in paperclipai/paperclip#4087 (`scripts/discord-daily-digest.sh`).

Closes #367.

## What

- New leaf node documenting: the script's purpose, the required `DISCORD_WEBHOOK_URL` env var, the optional `YYYY-MM-DD` date arg, the `master`-only `git log` enumeration, and `DRY_RUN=1` for previewing payloads.
- Soft link to `infrastructure/ci-cd/` since scheduling for outbound notifications conceptually belongs there. Flagged that no in-repo schedule exists today — the script is invoked externally.
- Listed under sub-domains in `infrastructure/NODE.md`.

## Why

The proposal in #367 noted no existing node described this outbound integration. Capturing it here means future agents touching notification scheduling or webhook configuration can find the source-of-truth without spelunking `scripts/`.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
