### PR TITLE
Add Better Auth cookie scoping tree node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@
 /engineering/                                      @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/better-auth-cookie-scoping/   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -66,6 +66,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 
 ## Sub-domains
 
+- [better-auth-cookie-scoping/](better-auth-cookie-scoping/) — Per-instance Better Auth cookie prefixes for local session isolation
 - [dev-runner/](dev-runner/) — Local development runner and worktree dev tooling
 - [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
 - [static-asset-serving/](static-asset-serving/) — Static asset cache headers and SPA fallback routing

--- a/engineering/backend/better-auth-cookie-scoping/NODE.md
+++ b/engineering/backend/better-auth-cookie-scoping/NODE.md
@@ -25,9 +25,9 @@ The instance-scoped prefix is always applied, including local HTTP development f
 
 ## Related
 
-- Worktree and local dev instance IDs are part of the dev environment tooling documented in `engineering/backend/dev-runner/worktree-dev-tooling/NODE.md`.
+- Worktree-local `PAPERCLIP_INSTANCE_ID` bootstrap is documented in `engineering/execution-workspaces/NODE.md`.
 
 ## Boundaries
 
 - This node covers auth-session isolation behavior in the backend auth layer.
-- General worktree provisioning and local dev tooling stay in `engineering/backend/dev-runner/`.
+- Worktree provisioning and runtime-state isolation stay in `engineering/execution-workspaces/NODE.md` and `engineering/backend/dev-runner/`.

--- a/engineering/backend/better-auth-cookie-scoping/NODE.md
+++ b/engineering/backend/better-auth-cookie-scoping/NODE.md
@@ -1,0 +1,33 @@
+---
+title: "Better Auth Cookie Scoping"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# Better Auth Cookie Scoping
+
+Better Auth uses a per-instance cookie prefix so multiple Paperclip servers running on the same host do not overwrite each other's session cookies.
+
+**Source:** `server/src/auth/better-auth.ts`
+
+## Key Decisions
+
+### Instance-Scoped Cookie Prefixes
+
+`deriveAuthCookiePrefix()` derives Better Auth's `advanced.cookiePrefix` from `PAPERCLIP_INSTANCE_ID`, producing cookies like `paperclip-<instance-id>`. This prevents multiple local servers bound to the same hostname from clobbering each other's sessions, which can happen because browser cookies are scoped by host rather than by port.
+
+### Sanitized and Stable Prefix Generation
+
+The derived prefix sanitizes the instance ID into a cookie-safe segment and falls back to `paperclip-default` when no usable instance ID is available. This keeps auth behavior deterministic even when the raw instance ID contains unsupported characters or resolves to an empty value.
+
+### Cookie Security and Cookie Scoping Are Independent
+
+The instance-scoped prefix is always applied, including local HTTP development flows where secure cookies are disabled. `useSecureCookies` controls transport security; `cookiePrefix` controls session isolation. Paperclip configures both so local development can remain usable without reintroducing cross-worktree session collisions.
+
+## Related
+
+- Worktree and local dev instance IDs are part of the dev environment tooling documented in `engineering/backend/dev-runner/worktree-dev-tooling/NODE.md`.
+
+## Boundaries
+
+- This node covers auth-session isolation behavior in the backend auth layer.
+- General worktree provisioning and local dev tooling stay in `engineering/backend/dev-runner/`.


### PR DESCRIPTION
## Summary
- add a backend decision node for instance-scoped Better Auth cookie prefixes
- document why cookie scoping stays enabled alongside the secure-cookie toggle
- link the new node from the backend domain index

## Context
- resolves #366
- source change: paperclipai/paperclip#4087
