### PR TITLE
tree: add engineering/frontend/user-profile-page node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,7 @@
 /engineering/frontend/issue-document-freshness/    @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-list-ux/               @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-thread-ux/             @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/user-profile-page/           @bingran-you @cryppadotta @serenakeyitan
 /engineering/mcp/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/mcp-server/                           @bingran-you @cryppadotta @serenakeyitan
 /engineering/shared/                               @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/frontend/NODE.md
+++ b/engineering/frontend/NODE.md
@@ -55,6 +55,14 @@ Pages live in `/ui/src/pages/` and map to top-level routes:
 - **Tailwind v4** (not v3) — uses the new CSS-first configuration approach.
 - **Adapter UI components are co-located with adapter packages** but imported into the main UI bundle for the management pages.
 
+## Sub-domains
+
+- [inbox-list/](inbox-list/) — Rendering and data-fetching patterns for the inbox list view
+- [issue-document-freshness/](issue-document-freshness/) — Freshness semantics for rendered issue documents
+- [issue-list-ux/](issue-list-ux/) — Issue list view interactions and data flow
+- [issue-thread-ux/](issue-thread-ux/) — Issue thread view interactions and data flow
+- [user-profile-page/](user-profile-page/) — Per-user profile page with activity, cost, and issue summaries
+
 ## Decision Records
 
 - [api-layer-and-react-query-over-global-state.md](api-layer-and-react-query-over-global-state.md) — Why frontend data flow is organized around a shared API layer plus React Query instead of a global store.

--- a/engineering/frontend/user-profile-page/NODE.md
+++ b/engineering/frontend/user-profile-page/NODE.md
@@ -1,0 +1,32 @@
+---
+title: "User Profile Page"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# User Profile Page
+
+Each company member has a profile page at `/:companySlug/u/:userSlug` (with an unprefixed redirect at `/u/:userSlug`). The page summarizes a user's participation in the company: identity, activity, cost, and issue involvement.
+
+## Data Shape
+
+The profile is served by `GET /companies/:companyId/users/:userSlug/profile` and returns a `UserProfileResponse` composed of:
+
+- **Identity** — slug, name, email, image, membership role + status, join date.
+- **Window stats** — three fixed windows (`last7`, `last30`, `all`) each reporting touched/created/completed/assigned-open issues, comment and activity counts, cost cents, and token totals (input, cached input, output) plus cost-event count.
+- **Daily points** — per-day activity count, completed issues, cost cents, and token breakdown for trend charts.
+- **Agent and provider usage** — cost/usage rollups per agent and per provider.
+- **Issue summary** — recent issues the user created, was assigned to, or acted on.
+
+## Key Decisions
+
+### Fixed Windows, Not Arbitrary Ranges
+
+Window keys are a closed set (`last7 | last30 | all`). This keeps server aggregation predictable and cacheable; ad-hoc ranges are intentionally out of scope.
+
+### Slug-Addressable Users
+
+The route keys on `userSlug`, not user UUID, so profile URLs are shareable and stable across renames of the underlying auth record.
+
+### Cost Attribution Lives Here
+
+User-level cost and token aggregation (by window, by day, by agent, by provider) is materialized on this endpoint rather than in a generic cost API, because the profile is the primary consumer and needs them pre-joined with activity counts.


### PR DESCRIPTION
## Summary

- Adds `engineering/frontend/user-profile-page/NODE.md` capturing the proposed node content from the gardener sync in #363: route, `UserProfileResponse` shape, and the fixed-window / slug-addressable / cost-attribution decisions.
- Adds a **Sub-domains** section to `engineering/frontend/NODE.md` that registers the new leaf alongside the existing `inbox-list`, `issue-document-freshness`, `issue-list-ux`, and `issue-thread-ux` leaves, matching the pattern used in `engineering/NODE.md` and `engineering/backend/NODE.md`.

Source PR: paperclipai/paperclip#4088 — _[codex] Add access cleanup and user profile page_.

Closes #363.

## Test plan

- [x] Node path matches the gardener proposal (`engineering/frontend/user-profile-page`)
- [x] Owners on the new NODE.md match the frontend parent (`bingran-you`, `cryppadotta`, `serenakeyitan`)
- [x] Parent `engineering/frontend/NODE.md` links to the new leaf from a Sub-domains section
- [ ] Node owners review rationale and sign off

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
