### PR TITLE
tree(backend/dev-runner): add dev-server-status-token node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/dev-runner/dev-server-status-token/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi

--- a/engineering/backend/dev-runner/NODE.md
+++ b/engineering/backend/dev-runner/NODE.md
@@ -18,3 +18,8 @@ Each execution workspace gets an isolated environment bootstrap — the dev runn
 When an agent resumes work on an existing branch, the dev runner reuses the linked worktree rather than creating a new one. This avoids worktree proliferation and preserves uncommitted workspace state across agent wake cycles.
 
 Source: `packages/server/` (execution workspace routes and dev runner modules).
+
+## Sub-domains
+
+- [dev-server-status-token/](dev-server-status-token/) — Per-process token that gates supervisor-only dev-server status on `/api/health`.
+- [worktree-dev-tooling/](worktree-dev-tooling/) — Dev-time asset routing, watch filtering, and workspace link repair.

--- a/engineering/backend/dev-runner/dev-server-status-token/NODE.md
+++ b/engineering/backend/dev-runner/dev-server-status-token/NODE.md
@@ -1,0 +1,25 @@
+---
+title: "Dev Server Status Token"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# Dev Server Status Token
+
+The dev runner and backend share a per-process secret that gates access to supervisor-only dev-server metadata on `/api/health`. The runner mints a random UUID at startup (`scripts/dev-runner.ts` / `.mjs`) and injects it into the child server as `PAPERCLIP_DEV_SERVER_STATUS_TOKEN`; the backend exposes dirty-state, pending migrations, and last-restart-at only when the request carries the matching `x-paperclip-dev-server-status-token` header.
+
+## Key Decisions
+
+### Dev Mode Only
+
+The token is generated only when the runner is in `dev` mode. In `watch` mode the env var is explicitly deleted so the embedded server does not expose supervisor metadata to any caller — dev-only diagnostics must never leak into watch or production runtimes.
+
+### Header, Not Cookie
+
+The runner attaches the token as a request header rather than a cookie so it cannot collide with Better Auth's instance-scoped cookies and is not subject to the 127.0.0.1 host-wide cookie jar used by worktree servers.
+
+## Related
+
+- Produced by the dev runner scripts under `engineering/backend/dev-runner/`.
+- Consumed by the health route in `server/src/routes/health.ts` (see `engineering/backend/`).
+
+Source PR: paperclipai/paperclip#4087.

--- a/engineering/backend/dev-runner/dev-server-status-token/NODE.md
+++ b/engineering/backend/dev-runner/dev-server-status-token/NODE.md
@@ -5,7 +5,7 @@ owners: [bingran-you, cryppadotta, serenakeyitan]
 
 # Dev Server Status Token
 
-The dev runner and backend share a per-process secret that gates access to supervisor-only dev-server metadata on `/api/health`. The runner mints a random UUID at startup (`scripts/dev-runner.ts` / `.mjs`) and injects it into the child server as `PAPERCLIP_DEV_SERVER_STATUS_TOKEN`; the backend exposes dirty-state, pending migrations, and last-restart-at only when the request carries the matching `x-paperclip-dev-server-status-token` header.
+The dev runner and backend share a per-process secret that lets the supervising dev runner read dev-server metadata on `/api/health` without needing a user session. The runner mints a random UUID at startup (`scripts/dev-runner.ts` / `.mjs`) and injects it into the child server as `PAPERCLIP_DEV_SERVER_STATUS_TOKEN`; the backend's health route returns the `devServer` block (dirty-state, pending migrations, last-restart-at) when the caller is already entitled to full details (e.g. board/agent actors) **or** when the request carries the matching `x-paperclip-dev-server-status-token` header. The token is an additional, actor-less path for the dev runner — not the exclusive gate.
 
 ## Key Decisions
 


### PR DESCRIPTION
## Summary

Drafts the `engineering/backend/dev-runner/dev-server-status-token/NODE.md` node proposed by the gardener in #365, and links it from the parent `engineering/backend/dev-runner/NODE.md` via a new Sub-domains section.

Source PR: paperclipai/paperclip#4087 — *[codex] Add backup endpoint and dev runtime hardening*.

Key decisions captured:
- The token is minted only in `dev` mode; `watch` mode explicitly unsets `PAPERCLIP_DEV_SERVER_STATUS_TOKEN` so supervisor metadata on `/api/health` is never exposed outside dev.
- Header (`x-paperclip-dev-server-status-token`), not cookie — avoids collisions with Better Auth instance-scoped cookies and the 127.0.0.1 host-wide cookie jar used by worktree servers.

CODEOWNERS regenerated via `first-tree tree generate-codeowners`.

Closes #365.

## Test plan

- [ ] Owners (`bingran-you`, `cryppadotta`, `serenakeyitan`) confirm the node content matches the decisions actually taken in paperclipai/paperclip#4087.
- [ ] Parent `engineering/backend/dev-runner/NODE.md` lists the new sub-domain.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
