### PR TITLE
[gardener] Document member archival governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,6 +81,7 @@
 /product/company-model/                            @bingran-you @cryppadotta @serenakeyitan
 /product/company-model/company-is-the-top-level-boundary.md @bingran-you @cryppadotta @serenakeyitan
 /product/governance/                               @bingran-you @cryppadotta @serenakeyitan
+/product/governance/member-archival.md             @bingran-you @cryppadotta @serenakeyitan
 /product/governance/server-enforced-approvals-and-budget-stops.md @bingran-you @cryppadotta @serenakeyitan
 /product/governance/issue-approvals/               @bingran-you @cryppadotta @serenakeyitan
 /product/routines/                                 @bingran-you @cryppadotta @serenakeyitan

--- a/product/governance/NODE.md
+++ b/product/governance/NODE.md
@@ -89,6 +89,7 @@ Every mutation writes to `activity_log`. Every approval decision is logged. Agen
 
 ## Decision Records
 
+- [member-archival.md](member-archival.md) — Why human company members are archived through a dedicated governance flow instead of being deleted or generically status-edited.
 - [server-enforced-approvals-and-budget-stops.md](server-enforced-approvals-and-budget-stops.md) — Why approvals, budget hard stops, and their audit trail are enforced in the server rather than delegated to agents or adapters.
 
 ## Sub-domains

--- a/product/governance/member-archival.md
+++ b/product/governance/member-archival.md
@@ -1,0 +1,45 @@
+---
+title: "Member Archival"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# Member Archival
+
+Removing a human from a company should revoke their access without erasing the
+history that explains past work, approvals, and ownership.
+
+## Decision
+
+Human company memberships use a dedicated archival flow that moves the
+membership into a terminal `archived` state instead of deleting the record or
+treating archival as a generic editable status. Archiving clears the member's
+direct permission grants, prevents removal of the last active owner, and can
+reassign the member's open issues to another active company principal.
+
+## Why
+
+Governance needs member removal to preserve auditability and historical task
+context. Deleting memberships would break the traceability of who previously
+owned work or held authority inside the company. Making archival a dedicated
+flow, rather than just another status update, ensures the owner-removal guard
+and work-reassignment rules always run when access is revoked.
+
+## Implications
+
+- Human membership lifecycle includes a terminal `archived` state that keeps
+  authored activity and past assignments intelligible while removing active
+  access.
+- Member-management surfaces should present archival as a separate action from
+  routine role or status edits.
+- Open issues assigned to an archived human must be reassigned as part of the
+  archival operation instead of silently remaining with an inactive assignee.
+- Company governance treats the last active owner as a protected role; archival
+  cannot bypass that invariant.
+- Agent lifecycle remains separate from human membership archival even when work
+  is reassigned to an agent.
+
+## Related Domains
+
+- [product company model](../company-model/NODE.md)
+- [product task system](../task-system/NODE.md)
+- [engineering backend](../../engineering/backend/NODE.md)


### PR DESCRIPTION
## Summary
- add a governance decision record for human member archival
- capture archival as a dedicated non-destructive governance flow
- link the new record from `product/governance/NODE.md`

## Context
- follows the implementation shipped in paperclipai/paperclip#4088
- addresses #362