### PR TITLE
tree(adapters): add hermes-local node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 /adapters/cursor-local/conservative-context-and-session-normalization.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/gemini-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/gemini-local/auth-expiry-and-turn-limit-awareness.md @bingran-you @cryppadotta @serenakeyitan
+/adapters/hermes-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/openclaw-gateway/                        @bingran-you @cryppadotta @serenakeyitan
 /adapters/openclaw-gateway/websocket-gateway-and-device-pairing.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/opencode-local/                          @bingran-you @cryppadotta @serenakeyitan

--- a/adapters/NODE.md
+++ b/adapters/NODE.md
@@ -71,6 +71,7 @@ All sessioned adapters share a common `sessionCodec` pattern that normalizes fie
 - **[codex-local/](codex-local/NODE.md)** — Codex CLI (OpenAI) adapter
 - **[cursor-local/](cursor-local/NODE.md)** — Cursor editor agent adapter
 - **[gemini-local/](gemini-local/NODE.md)** — Gemini CLI (Google) adapter
+- **[hermes-local/](hermes-local/NODE.md)** — Hermes local adapter
 - **[openclaw-gateway/](openclaw-gateway/NODE.md)** — OpenClaw WebSocket gateway adapter
 - **[opencode-local/](opencode-local/NODE.md)** — OpenCode CLI adapter
 - **[pi-local/](pi-local/NODE.md)** — Pi CLI adapter

--- a/adapters/hermes-local/NODE.md
+++ b/adapters/hermes-local/NODE.md
@@ -1,0 +1,29 @@
+---
+title: "Hermes Local Adapter"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["adapters", "engineering/backend", "engineering/frontend"]
+---
+
+# Hermes Local Adapter
+
+Adapter for **Hermes** (a local coding agent). Registered under adapter type key `hermes_local` and exposed in the UI as "Hermes Agent".
+
+**Source:** `packages/adapters/hermes-paperclip-adapter/` (referenced via `hermes-paperclip-adapter/ui`)
+**UI module:** `ui/src/adapters/hermes-local/index.ts`
+**Server registry:** `server/src/adapters/registry.ts`
+
+---
+
+## Config shape
+
+Unlike most adapters, Hermes stores its local command override under the field name `hermesCommand` rather than the shared `command` field. The UI builds its adapter config via `buildHermesConfig` from the Hermes package, and the generic `AgentConfigForm` special-cases `adapterType === "hermes_local"` to read/write `hermesCommand` instead of `command`.
+
+## Command override normalization
+
+Because older agent records (and the schema-backed config form) may still carry the command under the generic `command` key, the server registry runs a `normalizeHermesConfig` step before dispatching execution. It inspects both `ctx.config` and `ctx.agent.adapterConfig`, and when `hermesCommand` is missing but a non-empty string `command` is present, it copies `command` into `hermesCommand` so downstream execution honors the user's override. This preserves backward compatibility with agents created before Hermes moved to its dedicated config field.
+
+---
+
+## Related
+
+See [adapters/NODE.md](../NODE.md) for the adapter interface contract and other local adapters (Claude, Codex, Cursor, Gemini, OpenCode, Pi) which use the shared `command` field convention.

--- a/adapters/hermes-local/NODE.md
+++ b/adapters/hermes-local/NODE.md
@@ -8,7 +8,7 @@ soft_links: ["adapters", "engineering/backend", "engineering/frontend"]
 
 Adapter for **Hermes** (a local coding agent). Registered under adapter type key `hermes_local` and exposed in the UI as "Hermes Agent".
 
-**Source:** `packages/adapters/hermes-paperclip-adapter/` (referenced via `hermes-paperclip-adapter/ui`)
+**Source:** `server/src/adapters/registry.ts`, `ui/src/adapters/hermes-local/index.ts`, and `ui/src/components/AgentConfigForm.tsx`; Hermes-specific runtime helpers come from the external `hermes-paperclip-adapter` dependency referenced by `server/package.json` and `ui/package.json`.
 **UI module:** `ui/src/adapters/hermes-local/index.ts`
 **Server registry:** `server/src/adapters/registry.ts`
 


### PR DESCRIPTION
Adds `adapters/hermes-local/NODE.md` for the Hermes local adapter, which the tree was missing. Addresses the gardener sync proposal in #392 (source PR paperclipai/paperclip#3503).

## What the node captures

- **Config shape divergence** — Hermes stores its command override under `hermesCommand` rather than the shared `command` field used by every other local adapter.
- **`normalizeHermesConfig` backward-compat shim** — the server registry copies legacy `command` values into `hermesCommand` before dispatch, so older agent records still honor user overrides.

Execution details (builder function internals, form wiring) stay in the source repo; the node records the cross-domain constraint so future agents touching adapter config know Hermes is the exception.

## Files

- `adapters/hermes-local/NODE.md` (new)
- `adapters/NODE.md` — adds the sub-domain list entry

Closes #392

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
