### PR TITLE
docs(testing): add test-command-tiers decision node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,6 +58,7 @@
 /infrastructure/deployment/bind-presets/           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/testing/test-command-tiers.md      @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan
 /members/antonio-mello-ai/                         @antonio-mello-ai
 /members/aronprins/                                @aronprins

--- a/infrastructure/testing/NODE.md
+++ b/infrastructure/testing/NODE.md
@@ -15,7 +15,7 @@ Testing strategy, frameworks, and test organization for Paperclip.
 ### Unit Tests (Vitest)
 
 - Framework: Vitest (`^3.0.5`)
-- Run: `pnpm test:run` (single run), `pnpm test` (watch mode)
+- Run: `pnpm test` (cheap default, single run — aliases `test:run`), `pnpm test:watch` (watch mode)
 - Scope: Package-level logic -- shared utilities, server business logic, adapter behavior
 - Location: Co-located with source or in package-level test directories
 - Runs in: PR pipeline `verify` job and release `verify_canary`/`verify_stable` jobs
@@ -72,6 +72,7 @@ Both e2e and release-smoke workflows upload Playwright HTML reports and test res
 ## Decision Records
 
 - [no-llm-calls-in-default-ci.md](no-llm-calls-in-default-ci.md) — Why standard CI avoids required live model-provider calls.
+- [test-command-tiers.md](test-command-tiers.md) — Why `pnpm test` is the cheap Vitest-only default and browser suites stay opt-in.
 
 ---
 
@@ -79,8 +80,9 @@ Both e2e and release-smoke workflows upload Playwright HTML reports and test res
 
 | Command | What it runs |
 |---|---|
-| `pnpm test` | Vitest watch mode |
-| `pnpm test:run` | Vitest single run |
+| `pnpm test` | Vitest single run (cheap default; aliases `test:run`) |
+| `pnpm test:run` | Vitest single run (explicit) |
+| `pnpm test:watch` | Vitest watch mode |
 | `pnpm test:e2e` | Playwright e2e (headless) |
 | `pnpm test:e2e:headed` | Playwright e2e (visible browser) |
 | `pnpm test:release-smoke` | Release smoke Playwright suite |

--- a/infrastructure/testing/test-command-tiers.md
+++ b/infrastructure/testing/test-command-tiers.md
@@ -1,0 +1,29 @@
+---
+title: "Test Command Tiers"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["infrastructure/testing/NODE.md", "infrastructure/testing/no-llm-calls-in-default-ci.md"]
+---
+
+# Test Command Tiers
+
+Paperclip's test commands are split into tiers so that the default local and agent test path stays cheap. Contributors and agents should run `pnpm test` by default; browser suites are opt-in and run only when the change touches them or when explicitly verifying CI/release flows.
+
+## Key Decisions
+
+### `pnpm test` Runs Vitest Only
+
+The default `pnpm test` command runs the Vitest suite and nothing else. It does not run Playwright. This keeps the inner loop fast for both humans and agents and prevents unrelated browser flakiness from blocking unrelated work. `pnpm test:run` is the explicit non-watch variant (and `pnpm test` aliases it); `pnpm test:watch` is the interactive Vitest mode.
+
+### Browser Suites Stay Separate and Opt-In
+
+Playwright and release-smoke browser tests are exposed as distinct commands (`pnpm test:e2e`, `pnpm test:release-smoke`) rather than being folded into `pnpm test`. Run them when your change touches browser flows or when you are explicitly verifying CI/release behavior. CI still runs them in the appropriate pipelines, but local and agent defaults do not.
+
+### Verification Before Hand-off
+
+The `AGENTS.md` hand-off checklist uses the cheap default (`pnpm test`). Agents should not escalate to browser suites unless the diff touches UI end-to-end flows, because those suites are slower and noisier and will produce false negatives on unrelated changes.
+
+## Source
+
+- `package.json` — script definitions
+- `AGENTS.md`, `README.md`, `cli/README.md`, `doc/DEVELOPING.md` — contributor guidance
+- paperclipai/paperclip#3679 — PR that established this convention


### PR DESCRIPTION
## Summary

Resolves #384 — gardener sync-proposal for `infrastructure/testing/test-command-tiers`.

Adds a new decision node capturing the convention established by paperclipai/paperclip#3679:

- `pnpm test` is the cheap default and runs Vitest only (aliases `test:run`); it does not run Playwright.
- `pnpm test:watch` is the interactive Vitest mode.
- Browser suites (`pnpm test:e2e`, `pnpm test:release-smoke`) stay separate and opt-in.
- Agent hand-off checklists should use the cheap default and not escalate to browser suites unless the diff touches UI e2e flows.

Also updates `infrastructure/testing/NODE.md` so the Unit Tests section and the Test Commands Reference table reflect the new `pnpm test` = single run behavior.

## Verification

- `package.json` in paperclipai/paperclip confirms `"test": "pnpm run test:run"` and the new `test:watch` script.
- Source guidance lives in `AGENTS.md`, `README.md`, `cli/README.md`, `doc/DEVELOPING.md` per the gardener proposal.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
