### PR TITLE
Add task-system node for implicit reopen on agent comment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,7 @@
 /product/task-system/auto-checkout/                @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/comment-wake/                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/dependency-blocked-interaction/ @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/implicit-reopen-on-comment/   @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/inbox-search/                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-blockers/               @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-references/             @bingran-you @cryppadotta @serenakeyitan

--- a/product/task-system/NODE.md
+++ b/product/task-system/NODE.md
@@ -68,6 +68,7 @@ Fixed, non-customizable: No priority (0), Urgent (1), High (2), Medium (3), Low 
 
 ## Sub-domains
 
+- **[implicit-reopen-on-comment/](implicit-reopen-on-comment/NODE.md)** — Comment-driven return to `todo` when closed or resumable work is directed back to an agent
 - **[issue-blockers/](issue-blockers/NODE.md)** — First-class blocker relations and dependency wakeups between issues
 - **[dependency-blocked-interaction/](dependency-blocked-interaction/NODE.md)** — How blocked issues stay idle on deliverable work while still supporting human comment triage
 - **[issue-references/](issue-references/NODE.md)** — First-class mentions of issues inside other issues (PAP-123 style references, related-work summary)

--- a/product/task-system/NODE.md
+++ b/product/task-system/NODE.md
@@ -68,7 +68,7 @@ Fixed, non-customizable: No priority (0), Urgent (1), High (2), Medium (3), Low 
 
 ## Sub-domains
 
-- **[implicit-reopen-on-comment/](implicit-reopen-on-comment/NODE.md)** — Comment-driven return to `todo` when closed or resumable work is directed back to an agent
+- **[implicit-reopen-on-comment/](implicit-reopen-on-comment/NODE.md)** — Comment-driven return to `todo` when closed work is directed back to an agent
 - **[issue-blockers/](issue-blockers/NODE.md)** — First-class blocker relations and dependency wakeups between issues
 - **[dependency-blocked-interaction/](dependency-blocked-interaction/NODE.md)** — How blocked issues stay idle on deliverable work while still supporting human comment triage
 - **[issue-references/](issue-references/NODE.md)** — First-class mentions of issues inside other issues (PAP-123 style references, related-work summary)

--- a/product/task-system/implicit-reopen-on-comment/NODE.md
+++ b/product/task-system/implicit-reopen-on-comment/NODE.md
@@ -1,18 +1,18 @@
 ---
 title: "Implicit Reopen on Agent Comment"
 owners: [bingran-you, cryppadotta, serenakeyitan]
-soft_links: ["product/task-system/comment-wake/NODE.md", "product/task-system/issue-blockers/NODE.md", "engineering/frontend/issue-thread-ux/NODE.md"]
+soft_links: ["product/task-system/comment-wake/NODE.md", "engineering/frontend/issue-thread-ux/NODE.md"]
 ---
 
 # Implicit Reopen on Agent Comment
 
-Comments can move work back to `todo` without a separate reopen action when the comment targets an agent assignee. This applies to `done` and `cancelled` issues, and also to `blocked` issues that are resumable because they have no unresolved first-class blockers.
+Comments can move work back to `todo` without a separate reopen action when the comment targets an agent assignee. In the behavior introduced by `paperclipai/paperclip#3678`, this applies only to closed issues: `done` and `cancelled`.
 
 ## Key Decisions
 
 ### Agent-Targeted Comments Act as Resume Signals
 
-When a comment is posted through either the issue update path or the dedicated comment path, Paperclip treats it as a signal to resume work if the resulting assignee is an agent and the issue is in a resumable state. The backend is the source of truth: it performs the status transition back to `todo` and records `reopened` plus `reopenedFrom` in activity.
+When a comment is posted through either the issue update path or the dedicated comment path, Paperclip treats it as a signal to resume work if the resulting assignee is an agent and the issue is closed. The backend is the source of truth: it performs the status transition back to `todo` and records `reopened` plus `reopenedFrom` in activity.
 
 ### UI Predicts the Outcome but Does Not Own It
 
@@ -22,12 +22,11 @@ The issue thread composer no longer exposes a manual reopen toggle. Instead, the
 
 Implicit reopen is suppressed when the commenting actor is the same agent currently assigned to the issue. This prevents an agent from accidentally bouncing its own completed work back to `todo` by leaving a closing or follow-up comment.
 
-### Blocker Semantics Still Win
+### `blocked` Issues Are Out of Scope for This Behavior
 
-A `blocked` issue only resumes through this path when it is manually blocked and has no unresolved first-class blockers. Dependency-blocked work stays `blocked` until the blocker relation is actually cleared; comments alone do not override blocker semantics.
+`paperclipai/paperclip#3678` does not make comment-driven reopen apply to `blocked` issues. A comment alone does not turn blocked work back into `todo`; any blocked/resumable semantics must be documented against the source change that actually introduces them.
 
 ## Boundaries
 
 - Comment-triggered wake delivery after the reopen is defined in [Comment Wake](../comment-wake/NODE.md).
-- Dependency semantics for `blocked` work are defined in [Issue Blockers](../issue-blockers/NODE.md).
 - The composer interaction and hidden reopen control are frontend concerns described in [engineering/frontend/issue-thread-ux](../../../engineering/frontend/issue-thread-ux/NODE.md).

--- a/product/task-system/implicit-reopen-on-comment/NODE.md
+++ b/product/task-system/implicit-reopen-on-comment/NODE.md
@@ -1,0 +1,33 @@
+---
+title: "Implicit Reopen on Agent Comment"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["product/task-system/comment-wake/NODE.md", "product/task-system/issue-blockers/NODE.md", "engineering/frontend/issue-thread-ux/NODE.md"]
+---
+
+# Implicit Reopen on Agent Comment
+
+Comments can move work back to `todo` without a separate reopen action when the comment targets an agent assignee. This applies to `done` and `cancelled` issues, and also to `blocked` issues that are resumable because they have no unresolved first-class blockers.
+
+## Key Decisions
+
+### Agent-Targeted Comments Act as Resume Signals
+
+When a comment is posted through either the issue update path or the dedicated comment path, Paperclip treats it as a signal to resume work if the resulting assignee is an agent and the issue is in a resumable state. The backend is the source of truth: it performs the status transition back to `todo` and records `reopened` plus `reopenedFrom` in activity.
+
+### UI Predicts the Outcome but Does Not Own It
+
+The issue thread composer no longer exposes a manual reopen toggle. Instead, the UI predicts reopen based on the current issue status and the comment's assignment target so humans can reassign and comment in one step. The server independently enforces the same workflow semantics so direct API callers and automation follow the same rule.
+
+### Self-Authored Agent Comments Do Not Implicitly Reopen
+
+Implicit reopen is suppressed when the commenting actor is the same agent currently assigned to the issue. This prevents an agent from accidentally bouncing its own completed work back to `todo` by leaving a closing or follow-up comment.
+
+### Blocker Semantics Still Win
+
+A `blocked` issue only resumes through this path when it is manually blocked and has no unresolved first-class blockers. Dependency-blocked work stays `blocked` until the blocker relation is actually cleared; comments alone do not override blocker semantics.
+
+## Boundaries
+
+- Comment-triggered wake delivery after the reopen is defined in [Comment Wake](../comment-wake/NODE.md).
+- Dependency semantics for `blocked` work are defined in [Issue Blockers](../issue-blockers/NODE.md).
+- The composer interaction and hidden reopen control are frontend concerns described in [engineering/frontend/issue-thread-ux](../../../engineering/frontend/issue-thread-ux/NODE.md).


### PR DESCRIPTION
## Summary
- add `product/task-system/implicit-reopen-on-comment/NODE.md`
- capture the comment-driven resume/reopen behavior introduced by paperclipai/paperclip#3678
- index the new node from `product/task-system/NODE.md`

## Context
- Resolves #385
- Source PR: paperclipai/paperclip#3678
