### PR TITLE
tree(backend): add hermes-adapter-auth node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@
 /drift/paperclip-e392f6b1/product/task-system/issue-links/ @bingran-you @serenakeyitan
 /engineering/                                      @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/hermes-adapter-auth.md        @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -73,3 +73,4 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 ## Decision Records
 
 - [shared-api-and-actor-scoped-authorization.md](shared-api-and-actor-scoped-authorization.md) — Why board and agent traffic share one API surface, with authorization derived from a common request actor model.
+- [hermes-adapter-auth.md](hermes-adapter-auth.md) — Why the `hermes_local` adapter wraps execute to inject `PAPERCLIP_API_KEY` / `PAPERCLIP_RUN_ID` for agent identity attribution.

--- a/engineering/backend/hermes-adapter-auth.md
+++ b/engineering/backend/hermes-adapter-auth.md
@@ -1,0 +1,53 @@
+---
+title: "Hermes Adapter Auth Injection"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["adapters/shared-server-adapter-contract.md", "engineering/backend/shared-api-and-actor-scoped-authorization.md"]
+---
+
+# Hermes Adapter Auth Injection
+
+The Hermes local adapter (`hermes_local`) needs special handling in the server
+adapter registry so agent identity attribution flows through to Paperclip API
+calls the Hermes runtime makes on behalf of the agent.
+
+## Why
+
+`hermes-paperclip-adapter` predates the shared `authToken` field on
+`AdapterExecutionContext`. Without injection, Hermes-run agents would make
+Paperclip API calls under a server or board-user identity (or with no run id),
+breaking per-agent attribution on mutating writes (comments, issue updates,
+etc.) and making audit trails misleading.
+
+## How it works
+
+In `server/src/adapters/registry.ts`, the `hermes_local` adapter wraps the
+underlying `hermesExecute` with a shim that runs when an `authToken` is present
+on the execution context:
+
+- Injects `PAPERCLIP_API_KEY` into the adapter's `env` with the run-scoped
+  agent JWT, unless the agent's `adapterConfig.env` already sets it explicitly.
+- Injects `PAPERCLIP_RUN_ID` into the adapter's `env` from `ctx.runId` so
+  mutating requests can be correlated to the originating run.
+- Prepends an auth-guard instruction to any *custom* `promptTemplate` telling
+  the agent to send `Authorization: Bearer $PAPERCLIP_API_KEY` on Paperclip API
+  requests and `X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID` on writes, and to never
+  reuse a board/browser/local-board session for Paperclip API writes.
+
+Explicit caller configuration wins: if `adapterConfig.env.PAPERCLIP_API_KEY` is
+already set, the injected token is skipped. When no custom `promptTemplate`
+exists, Hermes' built-in default prompt is left intact — the auth guard is only
+prepended to custom templates so unconfigured agents keep Hermes' default
+heartbeat/task instructions.
+
+## Scope
+
+This shim is Hermes-specific. Other adapters consume `authToken` directly via
+their typed execution context. The `as unknown as ServerAdapterModule["execute"]`
+cast in `registry.ts` is intentional and should be removed once
+`hermes-paperclip-adapter` ships an `AdapterExecutionContext` type that
+includes `authToken`.
+
+## Source
+
+Introduced in paperclipai/paperclip#3608 — *fix(hermes): inject agent JWT into
+Hermes adapter env to fix identity attribution*.


### PR DESCRIPTION
## Summary

Drafts the `engineering/backend/hermes-adapter-auth.md` decision node proposed by the gardener in #390, and links it from the parent `engineering/backend/NODE.md` Decision Records list.

Source PR: paperclipai/paperclip#3608 — *fix(hermes): inject agent JWT into Hermes adapter env to fix identity attribution*.

Key decisions captured:
- The `hermes_local` adapter wraps `hermesExecute` to inject `PAPERCLIP_API_KEY` (from `ctx.authToken`) and `PAPERCLIP_RUN_ID` (from `ctx.runId`) into adapter env.
- Explicit caller config wins: if `adapterConfig.env.PAPERCLIP_API_KEY` is already set, injection is skipped.
- Auth-guard prompt is prepended only to *custom* `promptTemplate` values — Hermes' built-in default prompt stays intact.
- The shim is Hermes-specific because `hermes-paperclip-adapter` predates the shared `authToken` field on `AdapterExecutionContext`; the intentional `as unknown as` cast should be removed once Hermes ships a matching execution-context type.

Closes #390.

## Test plan
- [ ] Owners (`bingran-you`, `cryppadotta`, `serenakeyitan`) confirm the node content matches the decisions actually taken in paperclipai/paperclip#3608.
- [ ] Parent `engineering/backend/NODE.md` Decision Records list includes the new node.
- [ ] `CODEOWNERS` entry for the new file is present.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
