### PR TITLE
Add seeded worktree live-work quarantine node

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -p first-tree first-tree tree inject-context --skip-version-check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -p first-tree first-tree tree inject-context --skip-version-check",
+            "statusMessage": "Loading First Tree context"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi
 /engineering/backend/webhook-signing-modes/        @bingran-you @cryppadotta @serenakeyitan @antonio-mello-ai
+/engineering/backend/worktree-live-work-quarantine/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/cli/                                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/cli/cli-mirrors-api-and-instance-ops.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/contributor-guide/                    @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -68,6 +68,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 
 - [dev-runner/](dev-runner/) — Local development runner and worktree dev tooling
 - [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
+- [worktree-live-work-quarantine/](worktree-live-work-quarantine/) — Default quarantine of copied live execution state in seeded worktrees
 - [static-asset-serving/](static-asset-serving/) — Static asset cache headers and SPA fallback routing
 
 ## Decision Records

--- a/engineering/backend/worktree-live-work-quarantine/NODE.md
+++ b/engineering/backend/worktree-live-work-quarantine/NODE.md
@@ -1,0 +1,39 @@
+---
+title: "Seeded Worktree Live-Work Quarantine"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/execution-workspaces/NODE.md", "engineering/cli/NODE.md", "engineering/backend/heartbeat-run-orchestration/NODE.md"]
+---
+
+# Seeded Worktree Live-Work Quarantine
+
+When a worktree is seeded from a live source instance via `paperclipai worktree init`, `reseed`, or `repair`, Paperclip quarantines copied live execution state by default for both `minimal` and `full` seed modes. This prevents a freshly booted isolated worktree from resuming agent work that is still owned by the source instance.
+
+## Key Decisions
+
+### Quarantine by Default
+
+During restore, the CLI disables copied agent timer heartbeats, resets copied `running` agents to `idle`, blocks and unassigns copied agent-owned `in_progress` issues, and unassigns copied agent-owned `todo` and `in_review` issues. The seed flow summarizes these actions back to the operator, including counts such as disabled timer heartbeats and reset running agents.
+
+**Rationale:** A seeded worktree is meant to be an isolated sandbox. If it inherits live assignments and timers unchanged, it can silently race the source instance, causing duplicate runs, conflicting commits, or duplicate issue comments. Safe isolation is therefore the default behavior.
+
+### `--preserve-live-work` Is an Explicit Opt-In
+
+Operators who intentionally want a seeded worktree to resume copied assignments can pass `--preserve-live-work` to `worktree init`, `reseed`, or `repair`. There is no global configuration switch for this behavior; preserving copied live work always requires an explicit per-command opt-in.
+
+### Recovery Does Not Re-Link Seeded In-Progress Work
+
+Heartbeat orphaned-process recovery does not auto-resume seeded `in_progress` issues that no longer have run linkage. The quarantine clears `checkoutRunId` and `executionRunId`, and the recovery path only re-links issues that still have a real active or legacy execution run to attach to.
+
+**Rationale:** Quarantine and recovery must agree on the same safety invariant. Once copied live work has been intentionally detached during seeding, backend recovery should not reconstruct that linkage behind the operator's back.
+
+## Boundaries
+
+- `engineering/execution-workspaces` covers the broader worktree lifecycle and operator workflow.
+- `engineering/cli` covers the CLI command surface that applies this quarantine during init, reseed, and repair.
+- `engineering/backend/heartbeat-run-orchestration` covers the backend recovery behavior that respects the detached seeded state.
+
+## Source
+
+- `cli/src/commands/worktree.ts` — seeded-worktree quarantine and `--preserve-live-work`
+- `server/src/services/heartbeat.ts` — execution recovery logic that only re-links issues with real run linkage
+- `doc/DEVELOPING.md` — operator-facing worktree seeding documentation


### PR DESCRIPTION
## Summary
- add a dedicated node for seeded worktree live-work quarantine
- index it from `engineering/backend/NODE.md`
- add managed Codex/Claude context hook files so `first-tree tree verify` passes

## Validation
- `first-tree tree verify`

Closes #368.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.