### PR TITLE
Add deferred comment wake promotion node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/heartbeat-deferred-comment-promotion/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi
 /engineering/backend/webhook-signing-modes/        @bingran-you @cryppadotta @serenakeyitan @antonio-mello-ai

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -67,6 +67,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 ## Sub-domains
 
 - [dev-runner/](dev-runner/) — Local development runner and worktree dev tooling
+- [heartbeat-deferred-comment-promotion/](heartbeat-deferred-comment-promotion/) — Deferred comment wakes promoted after the active issue run releases execution
 - [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
 - [static-asset-serving/](static-asset-serving/) — Static asset cache headers and SPA fallback routing
 

--- a/engineering/backend/heartbeat-deferred-comment-promotion/NODE.md
+++ b/engineering/backend/heartbeat-deferred-comment-promotion/NODE.md
@@ -1,0 +1,34 @@
+---
+title: "Deferred Comment Wake Promotion"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/backend/heartbeat-run-orchestration/NODE.md", "product/task-system/comment-wake/NODE.md"]
+---
+
+# Deferred Comment Wake Promotion
+
+How the backend handles comments that arrive while an issue already has an active heartbeat run. Instead of starting a second overlapping run immediately, the wake is deferred and then promoted into a follow-up run during the active run's release step.
+
+**Source:** `server/src/services/heartbeat.ts`, `server/src/routes/issues.ts`, `server/src/services/issues.ts`
+
+## Key Decisions
+
+### Comments During Active Execution Defer Rather Than Overlap
+
+When a new issue comment arrives while the assigned agent already has an active run for that issue, the backend records a deferred wake request instead of launching a second concurrent execution. This preserves the low-latency comment-wake model without allowing overlapping runs to race on the same issue.
+
+### Promotion Happens During Release And Reuses Issue Context
+
+The deferred wake is promoted as part of `releaseIssueExecutionAndPromote`, after the active run releases execution on the issue. When the run includes an `issueId` in its context snapshot, the release step locks that specific issue row with `FOR UPDATE` rather than locking by `execution_run_id` alone. This narrows lock scope and keeps unrelated issues from contending on the same release path.
+
+### Deferred Comment Promotion Can Reopen Closed Issues
+
+If the active run closes the issue and deferred comment wakes exist for that same issue, promotion reopens the issue to `todo` before queuing the follow-up run. The promoted context carries the reopen provenance, and the backend logs a system activity entry with source `deferred_comment_wake` so the reopen is visible in audit history.
+
+### Automatic Run Summary Comments Are Fallback-Only
+
+Heartbeat finalization checks for an existing issue comment already tagged with the same `runId` before posting its generated run summary. If the run itself already wrote a completion comment, the fallback summary is suppressed and the run is marked satisfied by that existing comment. This prevents duplicate run-summary comments when finalize or promotion paths retry.
+
+## Boundaries
+
+- The decision to wake an agent on new comments remains part of [Comment Wake](../../../product/task-system/comment-wake/NODE.md).
+- This node covers the backend-side release, reopening, dedupe, and promotion mechanics after a comment wake collides with an already-running issue execution.

--- a/product/task-system/comment-wake/NODE.md
+++ b/product/task-system/comment-wake/NODE.md
@@ -1,6 +1,7 @@
 ---
 title: "Comment Wake"
 owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/backend/heartbeat-deferred-comment-promotion/NODE.md"]
 ---
 
 # Comment Wake
@@ -15,7 +16,11 @@ When a comment is posted on a task (by a human or another agent), the system tri
 
 ### Wake Efficiency
 
-Comment wakes are optimized for low latency. Rather than waiting for the next scheduled heartbeat, the system fires an immediate wake scoped to the commented issue. This ensures responsive agent behavior during active collaboration while avoiding unnecessary full-context rebuilds.
+Comment wakes are optimized for low latency. Rather than waiting for the next scheduled heartbeat, the system fires an immediate wake scoped to the commented issue whenever no run is already active for that issue. This ensures responsive agent behavior during active collaboration while avoiding unnecessary full-context rebuilds.
+
+### Deferred Promotion On Active-Run Collision
+
+When a comment arrives while the assigned agent already has an active run on the same issue, the wake is not fired immediately. Instead, it is recorded as a deferred wake request and promoted into a follow-up run during the active run's release step — preserving the low-latency comment-wake model without allowing overlapping runs to race on the same issue. Release-time promotion, reopen-on-promotion, and run-summary dedupe mechanics are owned by [Deferred Comment Wake Promotion](../../../engineering/backend/heartbeat-deferred-comment-promotion/NODE.md).
 
 ### Scoped Wake Payload
 
@@ -26,3 +31,4 @@ Comment wakes carry the issue scope, enabling downstream auto-checkout (see [Aut
 - The **heartbeat protocol** (scheduled periodic wakes) is defined in [Agent Model](../agent-model/NODE.md). Comment wake is an event-driven complement to scheduled heartbeats.
 - **Auto-checkout** behavior after wake is owned by [Auto-Checkout on Wake](auto-checkout/NODE.md).
 - **Worktree isolation** during the resulting execution is owned by [Execution Workspaces](../../engineering/execution-workspaces/NODE.md).
+- **Release-time deferred wake mechanics** (row-lock narrowing, reopen-on-promotion, run-comment dedupe) are owned by [Deferred Comment Wake Promotion](../../../engineering/backend/heartbeat-deferred-comment-promotion/NODE.md).


### PR DESCRIPTION
## Summary
- add `engineering/backend/heartbeat-deferred-comment-promotion/NODE.md`
- capture deferred comment wake promotion, row-lock narrowing, reopen-on-promotion, and run-comment dedupe
- link the new node from `engineering/backend/NODE.md`

## Context
- Sync proposal issue: #387
- Source PR: paperclipai/paperclip#3678

Closes #387