### PR TITLE
Add issue chat composer viewport node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 /engineering/frontend/                             @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/api-layer-and-react-query-over-global-state.md @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/inbox-list/                  @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/issue-chat-composer-viewport/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-document-freshness/    @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-list-ux/               @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-thread-ux/             @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/backend/heartbeat-run-orchestration/NODE.md
+++ b/engineering/backend/heartbeat-run-orchestration/NODE.md
@@ -1,6 +1,7 @@
 ---
 title: "Heartbeat Run Orchestration"
 owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/frontend/issue-chat-composer-viewport"]
 ---
 
 # Heartbeat Run Orchestration
@@ -39,3 +40,4 @@ Each state transition produces an immutable event in `heartbeat_run_events`, ena
 
 - The **heartbeat protocol** (when to fire, what context to include) is defined in `product/agent-model`. This node covers the **execution** of that protocol.
 - **Adapter execution mechanics** (process spawning, output parsing) are owned by `adapters/`. This node covers the **coordination** around adapter calls.
+- The **issue-chat stop-run control** that invokes heartbeat cancellation from the transcript UI is documented in `engineering/frontend/issue-chat-composer-viewport`.

--- a/engineering/frontend/issue-chat-composer-viewport/NODE.md
+++ b/engineering/frontend/issue-chat-composer-viewport/NODE.md
@@ -1,0 +1,31 @@
+---
+title: "Issue Chat Composer Viewport & Stop Run"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/backend/heartbeat-run-orchestration", "product/task-system/comment-wake", "product/task-system/issue-thread-ux"]
+---
+
+# Issue Chat Composer Viewport & Stop Run
+
+The issue chat thread preserves the composer's viewport position across re-renders and exposes a stop-run control so users can interrupt an in-flight agent run from the chat surface.
+
+## Key Decisions
+
+### Capture/Restore Composer Viewport
+
+`captureComposerViewportSnapshot` and `restoreComposerViewportSnapshot` in `ui/src/lib/issue-chat-scroll.ts` save the composer's viewport position before message-list re-renders and restore it after layout settles. `shouldPreserveComposerViewport` only enables restoration while the composer contains the active element, so the UI keeps the editing surface anchored during streaming updates without fighting intentional navigation.
+
+### Stable Thread Message Identity
+
+`stabilizeThreadMessages` produces a memoization-friendly message array keyed by stable message identity, reusing prior message objects when their content fingerprint has not changed. This prevents `@assistant-ui/react` from remounting thread rows on metadata-only updates, which reduces flicker and makes the composer viewport snapshot meaningful across live transcript updates.
+
+### Stop Run From Chat
+
+`canStopIssueChatRun` gates a Stop Run action for queued or running issue-linked runs directly from the chat transcript UI. The frontend sends comment mutations with `interrupt: true`, and the backend cancels the active heartbeat run before logging the comment and propagating the interrupted run id through wake and activity payloads. This complements the existing comment-wake and reopen flows by giving board users a direct interrupt path without leaving the issue chat surface.
+
+## Boundaries
+
+- This node covers the chat-surface UX and client-side rendering behavior.
+- Heartbeat lifecycle and cancellation semantics remain owned by `engineering/backend/heartbeat-run-orchestration/`.
+- Comment-triggered wake behavior remains owned by `product/task-system/comment-wake/`.
+
+Source: PR #3678 (`[codex] Improve issue detail and issue-list UX`)

--- a/product/task-system/comment-wake/NODE.md
+++ b/product/task-system/comment-wake/NODE.md
@@ -1,6 +1,7 @@
 ---
 title: "Comment Wake"
 owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/frontend/issue-chat-composer-viewport"]
 ---
 
 # Comment Wake
@@ -26,3 +27,4 @@ Comment wakes carry the issue scope, enabling downstream auto-checkout (see [Aut
 - The **heartbeat protocol** (scheduled periodic wakes) is defined in [Agent Model](../agent-model/NODE.md). Comment wake is an event-driven complement to scheduled heartbeats.
 - **Auto-checkout** behavior after wake is owned by [Auto-Checkout on Wake](auto-checkout/NODE.md).
 - **Worktree isolation** during the resulting execution is owned by [Execution Workspaces](../../engineering/execution-workspaces/NODE.md).
+- The **issue-chat stop-run control** complements comment wake by letting users interrupt an in-flight run from the transcript UI without changing the wake contract; that chat-surface UX is documented in `engineering/frontend/issue-chat-composer-viewport`.


### PR DESCRIPTION
## Summary
- add `engineering/frontend/issue-chat-composer-viewport/NODE.md`
- document composer viewport preservation during live chat rerenders
- capture chat-surface stop-run behavior and its backend/task-system boundaries

## Context
- addresses #389
- source PR: paperclipai/paperclip#3678
