### PR TITLE
Add product/workspace-commands node (Services + Jobs)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,4 +92,5 @@
 /product/task-system/issue-blockers/               @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-thread-ux/              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/vscode-task-interoperability/ @bingran-you @cryppadotta @serenakeyitan
+/product/workspace-commands/                       @bingran-you @cryppadotta @serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/product/NODE.md
+++ b/product/NODE.md
@@ -53,3 +53,4 @@ Paperclip is explicitly **not**: an agent runtime, a knowledge base, a SaaS, a g
 - **[task-system/](task-system/NODE.md)** -- Task hierarchy, workflow states, atomic checkout, inter-agent communication.
 - **[governance/](governance/NODE.md)** -- Board powers, approval gates, budget controls, cost tracking.
 - **[routines/](routines/NODE.md)** -- Scheduled and event-triggered automation definitions, draft lifecycle, concurrency policies.
+- **[workspace-commands/](workspace-commands/NODE.md)** -- Services + Jobs mental model for commands attached to project/execution workspaces; per-service desired state and control targets.

--- a/product/workspace-commands/NODE.md
+++ b/product/workspace-commands/NODE.md
@@ -1,0 +1,32 @@
+---
+title: "Workspace Commands"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/execution-workspaces/NODE.md", "product/task-system/NODE.md"]
+---
+
+# Workspace Commands
+
+Paperclip models the runnable commands attached to a project or execution workspace as **workspace commands**, replacing the previous "raw runtime JSON" as the primary mental model. Raw runtime config is still accepted for advanced use, but operators and the UI think in terms of two kinds of commands.
+
+## Two Kinds
+
+- **Services** — long-running commands that stay supervised. They have a desired state (`running` or `stopped`) and are started/stopped from the workspace UI.
+- **Jobs** — one-shot commands that run once and exit. They are triggered on demand from the workspace UI.
+
+A `WorkspaceCommandDefinition` (`id`, `name`, `kind`, `command`, `cwd`, `lifecycle`, `serviceIndex`, `disabledReason`, `rawConfig`, `source`) is the canonical description shared between backend, shared package, and UI. Helpers `listWorkspaceCommandDefinitions`, `listWorkspaceServiceCommandDefinitions`, `findWorkspaceCommandDefinition`, and `matchWorkspaceRuntimeServiceToCommand` convert the stored runtime config blob into this model and reconcile it with live runtime service rows.
+
+## Per-Service Desired State
+
+Both `ProjectWorkspaceRuntimeConfig` and `ExecutionWorkspaceConfig` carry an optional `serviceStates: WorkspaceRuntimeServiceStateMap` (`Record<string, 'running' | 'stopped'>`) alongside the legacy workspace-wide `desiredState`. This lets operators independently control each service within a workspace rather than flipping the whole workspace on or off.
+
+## Control Target
+
+Runtime control endpoints accept a `WorkspaceRuntimeControlTarget` (`workspaceCommandId` | `runtimeServiceId` | `serviceIndex`), so the UI can address a command by its stable definition id, by the live runtime service row, or by positional index — whichever is available at the call site.
+
+## Inheritance
+
+Execution workspaces inherit the project workspace's command definitions by default and may override them. Paperclip does not auto-start or auto-stop workspace services as part of issue execution or server boot — all lifecycle transitions are explicit UI actions.
+
+## Relationships
+
+Workspace commands are the product-level mental model for workspace runtime; the engineering realization (worktree isolation, runtime service table, provisioning) lives under [engineering/execution-workspaces/](../../engineering/execution-workspaces/NODE.md). Jobs and services remain distinct from the task system — they are infrastructure attached to a workspace, not units of agent work.


### PR DESCRIPTION
Addresses the gardener sync proposal in #381 (proposal_id `741e8fa9a0d1`, source PR paperclipai/paperclip#3680).

## What this adds

- `product/workspace-commands/NODE.md` — a product-level node capturing the two-kinds (Services + Jobs) mental model, the `WorkspaceCommandDefinition` as the canonical description, per-service desired state, and the `WorkspaceRuntimeControlTarget` discriminator.
- Updates `product/NODE.md` Sub-domains list.

## Why a product node (vs. only engineering)

PR #294 already proposes an engineering-layer node at `engineering/execution-workspaces/runtime-services` covering the typed protocol and service lifecycle. Issue #381 asks for a *product* node because the shift from "raw runtime JSON" to "workspace commands" is a new mental model operators and the UI think in — not just an implementation detail. The two nodes are complementary: product/ captures the *why* and what operators see; engineering/ captures runtime service rows, provisioning, and implementation surface.

## Reviewer notes

- Owners on `product/NODE.md` are the same as those carried into the new leaf (bingran-you, cryppadotta, serenakeyitan).
- Soft link back to `engineering/execution-workspaces/` so agents traversing either side see the other.

Closes #381

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
