### PR TITLE
tree(product/task-system): add dependency-blocked-interaction node

### DIFF
--- a/product/task-system/NODE.md
+++ b/product/task-system/NODE.md
@@ -69,6 +69,7 @@ Fixed, non-customizable: No priority (0), Urgent (1), High (2), Medium (3), Low 
 ## Sub-domains
 
 - **[issue-blockers/](issue-blockers/NODE.md)** — First-class blocker relations and dependency wakeups between issues
+- **[dependency-blocked-interaction/](dependency-blocked-interaction/NODE.md)** — How agents respond to interaction wakes (e.g. human comments) on blocked issues without treating deliverable work as unblocked
 
 ## Open Questions
 

--- a/product/task-system/dependency-blocked-interaction/NODE.md
+++ b/product/task-system/dependency-blocked-interaction/NODE.md
@@ -1,0 +1,30 @@
+---
+title: "Dependency-Blocked Interaction"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["product/task-system/issue-blockers/NODE.md", "product/task-system/comment-wake/NODE.md"]
+---
+
+# Dependency-Blocked Interaction
+
+When a heartbeat fires on an issue that still has unresolved blockers — for example, a human leaves a comment on a blocked parent — the agent must respond to the interaction without treating the underlying deliverable as unblocked. The wake prompt carries this as a first-class concept so adapters do not have to infer it.
+
+## Key Decisions
+
+### Blocked issues stay idle until the final blocker resolves
+
+Per `doc/execution-semantics.md`, Paperclip does not queue a regular heartbeat run for a blocked issue. The canonical wake for deliverable work on a blocked issue is `issue_blockers_resolved`, fired when the last blocker closes. Any wake that fires earlier (e.g. `issue_commented`) is an **interaction** wake, not a work wake.
+
+### Wake payload carries blocker context
+
+The Paperclip wake prompt payload now includes `dependencyBlockedInteraction: boolean`, `unresolvedBlockerIssueIds: string[]`, and `unresolvedBlockerSummaries` (id, identifier, title, status, priority per blocker). This lets the agent acknowledge the comment, triage it, or escalate without needing to re-query the blocker graph.
+
+### Default agent prompt codifies the behavior
+
+The default `DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE` now includes: "If woken by a human comment on a dependency-blocked issue, respond or triage the comment without treating the blocked deliverable work as unblocked." The rule is baked into the prompt so every adapter that uses the shared template inherits it.
+
+## Source
+
+- `packages/adapter-utils/src/server-utils.ts` — `dependencyBlockedInteraction`, `PaperclipWakeBlockerSummary`, default prompt.
+- `packages/adapter-utils/src/server-utils.test.ts` — "renders dependency-blocked interaction guidance".
+- `server/src/__tests__/heartbeat-dependency-scheduling.test.ts`.
+- `doc/execution-semantics.md` (blocker idle rule).


### PR DESCRIPTION
Drafts the proposed Context Tree node from #422 (gardener sync proposal `8df12d93a95a`) for owner review.

**Source PR:** paperclipai/paperclip#4223 — [codex] Harden heartbeat scheduling and runtime controls

## What this PR adds
- New node `product/task-system/dependency-blocked-interaction/NODE.md` capturing the decision that comment-driven wakes on a blocked issue are **interaction** wakes, not work wakes, and the wake payload + prompt now codify that distinction.
- Links the new node from `product/task-system/NODE.md` under Sub-domains.
- Soft-links the new node to `issue-blockers/` and `comment-wake/` since it sits at their intersection.

## Owner review
Owners per the parent NODE.md: @bingran-you, @cryppadotta, @serenakeyitan. Please confirm the node placement, rationale, and wording.

Closes #422.

---
This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
