### PR TITLE
docs(engineering/backend): add authz-hardening NODE.md (#456)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@
 /engineering/                                      @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/                              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/shared-api-and-actor-scoped-authorization.md @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/authz-hardening/              @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -66,6 +66,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 
 ## Sub-domains
 
+- [authz-hardening/](authz-hardening/) — Cross-cutting conventions for hardening authenticated HTTP routes
 - [dev-runner/](dev-runner/) — Local development runner and worktree dev tooling
 - [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
 - [worktree-live-work-quarantine/](worktree-live-work-quarantine/) — Default quarantine of copied live execution state in seeded worktrees

--- a/engineering/backend/authz-hardening/NODE.md
+++ b/engineering/backend/authz-hardening/NODE.md
@@ -1,0 +1,39 @@
+---
+title: "Authenticated Route Hardening"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["engineering/backend/NODE.md", "engineering/backend/shared-api-and-actor-scoped-authorization.md"]
+---
+
+# Authenticated Route Hardening
+
+Cross-cutting conventions for hardening authenticated HTTP routes against cross-tenant access, anonymous probing, and client-supplied attribution forgery. Applies to all routes under `/server/src/routes/` that run in `authenticated` deployment mode. Source: paperclipai/paperclip#3741.
+
+## Key Decisions
+
+### Derive Actor Attribution from the Session, Not the Request Body
+
+Approval resolution endpoints (`/api/approvals/:id/approve`, `/reject`, `/request-revision`) no longer accept a `decidedByUserId` field from the client. The `resolveApprovalSchema` and `requestApprovalRevisionSchema` validators drop that field entirely, and the route derives attribution from the authenticated actor (`actor.userId`). This prevents a caller from forging approval attribution by supplying another user's id in the request body. The same pattern applies to any endpoint where "who did this" must be trustworthy.
+
+### Redact Privileged Fields for Authenticated Members Without Admin Permission
+
+Agent detail and company agent list endpoints return `200` with `adapterConfig` and `runtimeConfig` redacted to `{}` for authenticated company members who lack the agent-admin permission, rather than `403`-ing the whole response. This lets members see that agents exist without leaking adapter/runtime secrets.
+
+### Reject Anonymous Access Before Resource Existence Checks
+
+Routes like `GET /api/heartbeat-runs/:id/issues`, `GET /api/skills/index`, and `GET /api/skills/:name` must return `401` for anonymous actors (`actor.type === "none"`) before performing any database lookup. This prevents anonymous callers from using existence-check timing or `404` vs `401` response differences as an enumeration oracle.
+
+### Redact Health Metadata for Anonymous Requests in Authenticated Mode
+
+`/health` responds with a minimal `{ status, version }` body for anonymous callers when the deployment is in `authenticated` mode, and only returns detailed metadata (dev-server status, DB probe detail) to authenticated actors. This keeps uptime probes working without leaking internal state to unauthenticated scanners.
+
+### Centralize Workspace Runtime Authz in a Helper Module
+
+Project and execution workspace runtime-service mutations go through `assertCanManageProjectWorkspaceRuntimeServices` and `assertCanManageExecutionWorkspaceRuntimeServices` in `server/src/routes/workspace-runtime-service-authz.ts`. New routes that touch workspace runtime config must call these helpers rather than re-implementing the checks inline.
+
+### Private Hostname Guard Gating
+
+`shouldEnablePrivateHostnameGuard` enables the hostname guard only when `deploymentExposure === "private"` (regardless of whether `deploymentMode` is `local_trusted` or `authenticated`). Public deployments never enable the guard. New deployment modes must explicitly opt in via this predicate.
+
+## How to Apply
+
+When adding a new authenticated route, mirror these patterns: never trust client-supplied actor identity, gate anonymous access explicitly at the top of the handler, redact privileged fields rather than refusing the whole response when the caller is authenticated-but-underprivileged, and route workspace-runtime mutations through the shared authz helper.


### PR DESCRIPTION
Adds `engineering/backend/authz-hardening/NODE.md`, drafted from gardener sync proposal #456.

## Summary
- Captures cross-cutting conventions for hardening authenticated HTTP routes introduced by paperclipai/paperclip#3741.
- Covers actor-derived attribution, privileged-field redaction, anonymous-access gating before existence checks, health metadata redaction, the centralized workspace-runtime authz helpers, and private hostname guard gating.
- Links the new sub-domain from `engineering/backend/NODE.md` and soft-links back to the shared-api decision record.

Closes #456.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
