### PR TITLE
tree: add issue-list-payload-trimming node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/hermes-adapter-auth/          @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/issue-list-payload-trimming/  @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi
 /engineering/backend/webhook-signing-modes/        @bingran-you @cryppadotta @serenakeyitan @antonio-mello-ai
@@ -46,6 +47,7 @@
 /engineering/frontend/inbox-list/                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-chat-composer-viewport/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-document-freshness/    @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/issue-editor-reliability/    @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-list-nesting-and-server-search/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-list-ux/               @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-thread-ux/             @bingran-you @cryppadotta @serenakeyitan
@@ -95,6 +97,7 @@
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/auto-checkout/                @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/comment-cancellation/         @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/comment-wake/                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/dependency-blocked-interaction/ @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/inbox-search/                 @bingran-you @cryppadotta @serenakeyitan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/issue-list-payload-trimming/  @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi
 /engineering/backend/webhook-signing-modes/        @bingran-you @cryppadotta @serenakeyitan @antonio-mello-ai
 /engineering/backend/worktree-live-work-quarantine/ @bingran-you @cryppadotta @serenakeyitan

--- a/engineering/backend/NODE.md
+++ b/engineering/backend/NODE.md
@@ -70,6 +70,7 @@ Config is loaded from environment variables, `.env` files, and a YAML config fil
 - [heartbeat-run-orchestration/](heartbeat-run-orchestration/) — Run lifecycle state machine and process recovery
 - [worktree-live-work-quarantine/](worktree-live-work-quarantine/) — Default quarantine of copied live execution state in seeded worktrees
 - [static-asset-serving/](static-asset-serving/) — Static asset cache headers and SPA fallback routing
+- [issue-list-payload-trimming/](issue-list-payload-trimming/) — Dedicated list projection that truncates description and drops heavy columns
 
 ## Decision Records
 

--- a/engineering/backend/issue-list-payload-trimming/NODE.md
+++ b/engineering/backend/issue-list-payload-trimming/NODE.md
@@ -1,0 +1,20 @@
+---
+title: "Issue List Payload Trimming"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+---
+
+# Issue List Payload Trimming
+
+The issues list endpoint uses a dedicated `issueListSelect` projection in `server/src/services/issues.ts` that bounds payload size. `description` is truncated server-side via Postgres `substring(... FROM 1 FOR 1200)`; `executionPolicy`, `executionState`, and `executionWorkspaceSettings` are excluded from list reads entirely. Full values are only loaded on the issue detail endpoint.
+
+This keeps the issues index route fast and the response JSON bounded even when an issue accumulates large execution history or a long description. The 1200-character cap (`ISSUE_LIST_DESCRIPTION_MAX_CHARS`) is a display-oriented limit — list UIs show previews, not full bodies.
+
+## Key Decisions
+
+### Default New Unbounded Columns To List-Excluded
+
+When adding new columns to the `issues` table that can grow unbounded (long text, JSON history, settings blobs), default to excluding them from `issueListSelect` and exposing them only on detail routes. Anything expected to stay small (flags, ids, short enums) can stay in the list projection.
+
+### Truncate In SQL, Not In Node
+
+`description` truncation runs in Postgres via `substring(... FROM 1 FOR 1200)` rather than post-fetch in Node. This keeps the row bytes the server pulls over the wire bounded even before JSON serialization, which matters most when a company has many issues with long descriptions.


### PR DESCRIPTION
Adds `engineering/backend/issue-list-payload-trimming/NODE.md` to capture the backend convention introduced in paperclipai/paperclip#3779:

- Dedicated `issueListSelect` projection in `server/src/services/issues.ts`
- `description` truncated server-side to 1200 chars via Postgres `substring`
- `executionPolicy`, `executionState`, `executionWorkspaceSettings` excluded from list reads
- New unbounded `issues` columns default to list-excluded

Closes #452.

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
