### PR TITLE
docs(tree): add adapter capability flags node

### DIFF
--- a/adapters/NODE.md
+++ b/adapters/NODE.md
@@ -26,6 +26,7 @@ Every adapter implements the `ServerAdapterModule` interface from `@paperclipai/
 - **`detectModel`** — Read the agent's local config to discover the active model.
 - **`getConfigSchema`** — Declarative UI config schema so the frontend can render adapter-specific settings without custom React code.
 - **`onHireApproved`** — Lifecycle hook when an agent is approved/hired.
+- **Capability flags** — Optional fields on `ServerAdapterModule` declare support for managed instructions bundles, local JWT auth, and runtime-skill materialization so the server and UI can gate local-only features without hardcoded adapter-type lists.
 
 ### Three-Layer Package Structure
 
@@ -68,6 +69,7 @@ All sessioned adapters share a common `sessionCodec` pattern that normalizes fie
 ## Sub-domains
 
 - **[claude-local/](claude-local/NODE.md)** — Claude Code (Anthropic CLI) adapter
+- **[capability-flags/](capability-flags/NODE.md)** — Declarative adapter capability flags used by the server and UI
 - **[codex-local/](codex-local/NODE.md)** — Codex CLI (OpenAI) adapter
 - **[cursor-local/](cursor-local/NODE.md)** — Cursor editor agent adapter
 - **[gemini-local/](gemini-local/NODE.md)** — Gemini CLI (Google) adapter

--- a/adapters/capability-flags/NODE.md
+++ b/adapters/capability-flags/NODE.md
@@ -1,0 +1,52 @@
+---
+title: "Adapter Capability Flags"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: ["adapters", "engineering/backend/NODE.md", "engineering/frontend/NODE.md", "product/agent-model/adapter-defined-agent-internals.md"]
+---
+
+# Adapter Capability Flags
+
+Adapters declare which Paperclip-managed runtime features they support through optional capability fields on `ServerAdapterModule`. The server and UI consult these flags instead of maintaining hardcoded adapter-type allowlists and denylists for "local" behaviors.
+
+**Source:** `packages/adapter-utils/src/types.ts`, `server/src/routes/adapters.ts`, `server/src/routes/agents.ts`, `ui/src/adapters/use-adapter-capabilities.ts`
+
+---
+
+## Decision
+
+Paperclip models adapter-specific local behaviors as adapter-declared capabilities, not as special cases attached to a fixed set of built-in adapter type names.
+
+## Why
+
+External adapter plugins previously could not participate in local-adapter features such as managed instructions bundles, runtime-skill syncing, or local JWT auth unless Paperclip source code was updated to add their type to multiple server and UI lists. Capability flags let adapters opt into those behaviors through the shared adapter contract.
+
+## Capability Surface
+
+- **`supportsLocalAgentJwt`** — whether heartbeat should mint a local JWT for runs using the adapter.
+- **`supportsInstructionsBundle`** — whether the adapter supports the managed instructions bundle workflow and corresponding UI editor.
+- **`instructionsPathKey`** — which `adapterConfig` key stores the instructions file path when instructions bundles are supported.
+- **`requiresMaterializedRuntimeSkills`** — whether Paperclip must write runtime skill entries to disk before execution instead of passing them only through config.
+- **Derived `supportsSkills`** — computed server-side from `listSkills` or `syncSkills` and exposed alongside the explicit flags.
+
+## API Contract
+
+`GET /api/adapters` returns a `capabilities` object for each adapter entry. The frontend caches this through a dedicated capability hook and uses it to decide whether to show local-only affordances such as the instructions bundle editor, skill-management UI, and legacy working-directory behavior.
+
+## Compatibility Rules
+
+When an adapter does not set the explicit capability flags, the server keeps backward compatibility by falling back to legacy hardcoded maps and sets for built-in adapter types. For external adapters, omitted explicit flags default to `false`, so features such as local JWT auth, instructions bundles, and runtime-skill materialization still require an explicit opt-in. `supportsSkills` is different: the server derives it from `listSkills` or `syncSkills`, so adapters can surface skill-management UI without adding a separate flag.
+
+Built-in adapters are expected to declare their flags directly so the contract becomes self-describing over time instead of depending on the fallback path.
+
+## Implications
+
+- Adding a new adapter usually means declaring its capabilities in the adapter module, not editing core server or UI lists.
+- "Local" is treated as a bundle of specific capabilities rather than a permanent adapter category.
+- Product differences between runtimes stay adapter-defined, which keeps the control plane extensible for plugin adapters and future runtimes.
+
+## Related Domains
+
+- [adapters](../NODE.md)
+- [engineering backend](../../engineering/backend/NODE.md)
+- [engineering frontend](../../engineering/frontend/NODE.md)
+- [product agent model](../../product/agent-model/NODE.md)


### PR DESCRIPTION
## Summary
- add `adapters/capability-flags/NODE.md` capturing the adapter capability-flag architecture introduced in paperclipai/paperclip#3540
- link the new node from `adapters/NODE.md` (interface summary + sub-domains)
- reuses the owner-refined wording validated on closed PR #405 — `supportsSkills` is called out as a derived capability from `listSkills` / `syncSkills`; omitted explicit flags still default to `false` for external adapters

## Context
Drafted in response to gardener sync-proposal #469 (proposal_id `a3f1a67297ec`). The prior PR #405 covering the same node was intentionally closed ("onboarding test cleanup before fresh-release retest"); this PR reopens the tree change on a deterministic branch so owners can re-review against the current release cadence.

## Validation
- `npx -y -p first-tree first-tree tree verify` — the new node validates cleanly. The remaining repo-level failures are pre-existing on `main` (missing frontmatter on `adapters/hermes-local`, `engineering/backend/hermes-adapter-auth`, `engineering/frontend/issue-editor-reliability`, `product/task-system/comment-cancellation`) and are unrelated to this change.

Closes #469

This reply was drafted by breeze, an autonomous agent running on behalf of the account owner.
