### PR TITLE
sync(paperclip-e392f6b1): [codex] Improve issue thread review flow (from paperclipai/paperclip#4381)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 /*                                                 @bingran-you @serenakeyitan
 /adapters/                                         @bingran-you @cryppadotta @serenakeyitan
 /adapters/shared-server-adapter-contract.md        @bingran-you @cryppadotta @serenakeyitan
+/adapters/capability-flags/                        @bingran-you @cryppadotta @serenakeyitan
 /adapters/claude-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/claude-local/stream-json-and-headless-permissions.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/codex-local/                             @bingran-you @cryppadotta @serenakeyitan
@@ -12,6 +13,7 @@
 /adapters/cursor-local/conservative-context-and-session-normalization.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/gemini-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/gemini-local/auth-expiry-and-turn-limit-awareness.md @bingran-you @cryppadotta @serenakeyitan
+/adapters/hermes-local/                            @bingran-you @cryppadotta @serenakeyitan
 /adapters/openclaw-gateway/                        @bingran-you @cryppadotta @serenakeyitan
 /adapters/openclaw-gateway/websocket-gateway-and-device-pairing.md @bingran-you @cryppadotta @serenakeyitan
 /adapters/opencode-local/                          @bingran-you @cryppadotta @serenakeyitan
@@ -31,6 +33,9 @@
 /engineering/backend/dev-runner/                   @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/dev-runner/worktree-dev-tooling/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/heartbeat-run-orchestration/  @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/hermes-adapter-auth/          @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/issue-descendant-filter/      @bingran-you @cryppadotta @serenakeyitan
+/engineering/backend/issue-routine-execution-filter/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/backend/static-asset-serving/         @bingran-you @cryppadotta @serenakeyitan @stubbi
 /engineering/backend/webhook-signing-modes/        @bingran-you @cryppadotta @serenakeyitan @antonio-mello-ai
 /engineering/backend/worktree-live-work-quarantine/ @bingran-you @cryppadotta @serenakeyitan
@@ -46,6 +51,7 @@
 /engineering/frontend/inbox-list/                  @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-chat-composer-viewport/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-document-freshness/    @bingran-you @cryppadotta @serenakeyitan
+/engineering/frontend/issue-editor-reliability/    @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-list-nesting-and-server-search/ @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-list-ux/               @bingran-you @cryppadotta @serenakeyitan
 /engineering/frontend/issue-thread-ux/             @bingran-you @cryppadotta @serenakeyitan
@@ -65,6 +71,7 @@
 /infrastructure/discord-daily-digest/              @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/                           @bingran-you @cryppadotta @serenakeyitan
 /infrastructure/testing/no-llm-calls-in-default-ci.md @bingran-you @cryppadotta @serenakeyitan
+/infrastructure/testing/test-command-tiers/        @bingran-you @cryppadotta @serenakeyitan
 /members/                                          @bingran-you @serenakeyitan
 /members/antonio-mello-ai/                         @antonio-mello-ai
 /members/aronprins/                                @aronprins
@@ -96,6 +103,7 @@
 /product/task-system/                              @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/tasks-are-the-communication-channel.md @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/auto-checkout/                @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/comment-cancellation/         @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/comment-wake/                 @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/dependency-blocked-interaction/ @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/inbox-search/                 @bingran-you @cryppadotta @serenakeyitan
@@ -103,5 +111,7 @@
 /product/task-system/issue-references/             @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-thread-interactions/    @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/issue-thread-ux/              @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/loose-review-instructions/    @bingran-you @cryppadotta @serenakeyitan
+/product/task-system/run-liveness-continuations/   @bingran-you @cryppadotta @serenakeyitan
 /product/task-system/vscode-task-interoperability/ @bingran-you @cryppadotta @serenakeyitan
 /README.md                                         @bingran-you @serenakeyitan

--- a/engineering/backend/issue-descendant-filter/NODE.md
+++ b/engineering/backend/issue-descendant-filter/NODE.md
@@ -1,0 +1,27 @@
+---
+title: "Issue Descendant Filter"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: [engineering/backend/NODE.md, engineering/database/NODE.md, engineering/frontend/issue-list-ux/NODE.md, product/task-system/NODE.md]
+---
+
+# Issue Descendant Filter
+
+The issue list API supports a `descendantOf=<issueId>` filter that returns every issue in the descendant subtree of a given root issue, not just direct children.
+
+## Key Decisions
+
+### Recursive CTE Over Application-Level Traversal
+
+The filter is implemented as a recursive SQL CTE inside `issueService.list` rather than a multi-round-trip walk in application code. The CTE seeds with all direct children of `descendantOf` within the same `companyId` and unions in deeper generations until exhaustion. This keeps the entire subtree query in one round trip, which matters for issue trees that can be many levels deep.
+
+### Distinct From `parentId`
+
+`parentId` already filters to direct children only. `descendantOf` is a separate filter, not a replacement — both can coexist on the same query. The naming makes the depth semantics explicit at the API layer (`/companies/:id/issues?descendantOf=...`).
+
+### Company-Scoped at Every Recursion Level
+
+The CTE applies `companyId = ?` at both the seed and recursive step. This preserves Paperclip's company isolation invariant even inside recursive traversal — there is no path through which a descendant query could cross company boundaries.
+
+### UI Plumbing
+
+`issuesApi.list` accepts `descendantOf` and serializes it into the query string; the UI uses it to render full descendant lists for a root issue.

--- a/product/task-system/loose-review-instructions/NODE.md
+++ b/product/task-system/loose-review-instructions/NODE.md
@@ -1,0 +1,27 @@
+---
+title: "Loose Review Instructions"
+owners: [bingran-you, cryppadotta, serenakeyitan]
+soft_links: [engineering/backend/heartbeat-run-orchestration/NODE.md, product/governance/issue-approvals/NODE.md, product/task-system/NODE.md, product/task-system/issue-thread-interactions/NODE.md]
+---
+
+# Loose Review Instructions
+
+When an agent finishes work on an issue and hands off to a reviewer through the execution policy, it can attach free-form **review instructions** to the handoff. These instructions guide the reviewer (human or agent) about what to focus on — e.g. "check failure handling" or "verify against the reproduction steps" — without being structured into the policy itself.
+
+## Key Decisions
+
+### Loose Instructions, Not Structured Checklists
+
+The `reviewRequest` payload carries a single `instructions` string (1–20,000 chars, trimmed). It is intentionally unstructured — the coder writes prose for the reviewer. The system does not parse, validate, or enforce specific review criteria; it just propagates the text. This keeps the handoff lightweight and avoids prematurely formalizing a review checklist schema.
+
+### Lives on Execution State, Cleared on Transition
+
+`reviewRequest` is stored on `IssueExecutionState` alongside `currentParticipant` and `returnAssignee`. When a stage transitions (review approved / changes requested), the field is cleared so stale instructions don't leak across stages. Callers can also explicitly null it during a transition.
+
+### Surfaced in the Reviewer's Wake Prompt
+
+When the reviewer is woken via heartbeat, the rendered Paperclip wake prompt includes the instructions verbatim under "Review request instructions:". This is how the reviewer agent actually sees the guidance — it is not a UI-only field.
+
+### Set Through the Issue Update Endpoint
+
+The `PATCH /issues/:id` endpoint accepts an optional `reviewRequest` field. An agent providing only `reviewRequest` (with no other update fields) still counts as an agent work update, so the handoff fires even when the coder is just attaching review guidance alongside a status change to `done` / `in_review`.


### PR DESCRIPTION
Automated drift sync for source `paperclip-e392f6b1`.

- Source range: 5d1ed71..d0bdbe1
- Proposal files: 2

Proposals:
- TREE_MISS: product/task-system/loose-review-instructions/NODE.md — PR adds a new first-class `reviewRequest.instructions` field on issue execution state that flows from the coder's status update, through the execution policy transition, into the reviewer's wake prompt — no existing node captures this loose review handoff concept.
- TREE_MISS: engineering/backend/issue-descendant-filter/NODE.md — PR adds a new `descendantOf` filter on the issue list API backed by a recursive CTE that returns the full descendant tree of a root issue — a new query capability not described by any existing node.

Commits:
- [`6e6f538`](https://github.com/paperclipai/paperclip/commit/6e6f5386302045e7df5598cc16705f0e7b0ef76f) [codex] Improve issue detail and issue-list UX (#3678)
- [`e890761`](https://github.com/paperclipai/paperclip/commit/e89076148a577e1b279d0191c7699011488433ce) [codex] Improve workspace runtime and navigation ergonomics (#3680)
- [`7f893ac`](https://github.com/paperclipai/paperclip/commit/7f893ac4ec9f700efaf902be8a57ce510c1c7092) [codex] Harden execution reliability and heartbeat tooling (#3679)
- [`213bcd8`](https://github.com/paperclipai/paperclip/commit/213bcd8c7ab8e4a3839852ff7bd14f4383fc0bac) fix: include routine-execution issues in agent inbox-lite (#3329)
- [`d0a8d4e`](https://github.com/paperclipai/paperclip/commit/d0a8d4e08a5a7d55e0ade6c4906830ae5699b9cb) fix(routines): include cronExpression and timezone in list trigger response (#3209)
- [`b816809`](https://github.com/paperclipai/paperclip/commit/b816809a1e84a2ed7a8fc57fa0223a61814f147d) fix(server): respect externally set PAPERCLIP_API_URL env var (#3472)
- [`f6ce976`](https://github.com/paperclipai/paperclip/commit/f6ce9765449db5ebcf1497530379eb87f135ce81) fix: Anthropic subscription quota always shows 100% used (#3589)
- [`50cd76d`](https://github.com/paperclipai/paperclip/commit/50cd76d8a3f2fc06d1a5af63840abd3d7a1bcd02) feat(adapters): add capability flags to ServerAdapterModule (#3540)
- [`32a9165`](https://github.com/paperclipai/paperclip/commit/32a9165ddf6308f3b46eae0653b6f583e502e538) [codex] harden authenticated routes and issue editor reliability (#3741)
- [`f460f74`](https://github.com/paperclipai/paperclip/commit/f460f744eff5832dc38dc89eb131e3becb229e61) fix: trust PAPERCLIP_PUBLIC_URL in board mutation guard (#3731)
- [`6059c66`](https://github.com/paperclipai/paperclip/commit/6059c665d5ef72e11198981d54cf038a8368c0a6) fix(a11y): remove maximum-scale and user-scalable=no from viewport (#3726)
- [`0d87fd9`](https://github.com/paperclipai/paperclip/commit/0d87fd9a11e4c6d732e8695ece13ddc69b4a6265) fix: proper cache headers for static assets and SPA fallback (#3734)
- [`3905027`](https://github.com/paperclipai/paperclip/commit/390502736c320d6fbeb3f789f52a210a1dfc4a45) chore(ui): drop console.* and legal comments in production builds (#3728)
- [`c1a0249`](https://github.com/paperclipai/paperclip/commit/c1a02497b0a593b35364aa16452bec97d3b86ad9) [codex] fix worktree dev dependency ergonomics (#3743)
- [`3fa5d25`](https://github.com/paperclipai/paperclip/commit/3fa5d25de16a919c3dc3adc6085447efcb880108) [codex] harden heartbeat run summaries and recovery context (#3742)
- [`7463479`](https://github.com/paperclipai/paperclip/commit/7463479fc82904fd1965ba21ad9059195963e406) fix: disable HTTP caching on run log endpoints (#3724)
- [`d4c3899`](https://github.com/paperclipai/paperclip/commit/d4c3899ca4c9c2abfbcbeab8056a9036f30daf34) [codex] improve issue and routine UI responsiveness (#3744)
- [`5f45712`](https://github.com/paperclipai/paperclip/commit/5f457128463cbdc9d2282dacb3dfa44bc99fceb1) Sync/master post pap1497 followups 2026 04 15 (#3779)
- [`b8725c5`](https://github.com/paperclipai/paperclip/commit/b8725c52eff66cdea8cb223f1ca885475a254468) release: v2026.416.0 notes (#3782)
- [`1afb6be`](https://github.com/paperclipai/paperclip/commit/1afb6be961550694ca9d537cc97a27306950edab) fix(heartbeat): add hermes_local to SESSIONED_LOCAL_ADAPTERS (#3561)
- [`f701c3e`](https://github.com/paperclipai/paperclip/commit/f701c3e78c1164be7a4acd7a4c3dafd526d420d8) feat(claude-local): add Opus 4.7 to adapter model dropdown (#3828)
- [`e458145`](https://github.com/paperclipai/paperclip/commit/e4581455836e407a2feb1150bfd278381985bc69) docs: add public roadmap and update contribution policy for feature PRs (#3835)
- [`407e76c`](https://github.com/paperclipai/paperclip/commit/407e76c1dbd3c47c50f2cf4a1c09f96866c30b81) [codex] Fix Docker gh installation (#3844)
- [`e93e418`](https://github.com/paperclipai/paperclip/commit/e93e418cbf7997a29ff258d51d761572e69bda92) fix: add ssh client and jq to production image (#3826)
- [`b9a80dc`](https://github.com/paperclipai/paperclip/commit/b9a80dcf226c50c8778a70443e41557980376a03) feat: implement multi-user access and invite flows (#3784)
- [`236d11d`](https://github.com/paperclipai/paperclip/commit/236d11d36fc9ab95c558233d5f35f3aa62b588ad) [codex] Add run liveness continuations (#4083)
- [`e89d3f7`](https://github.com/paperclipai/paperclip/commit/e89d3f7e11fc1e85a04c912d03996886ba3a85dc) [codex] Add backup endpoint and dev runtime hardening (#4087)
- [`d8b63a1`](https://github.com/paperclipai/paperclip/commit/d8b63a18e7c06bc7ff3bd6a32227aa1f47fa3fd6) [codex] Add access cleanup and user profile page (#4088)
- [`fee514e`](https://github.com/paperclipai/paperclip/commit/fee514efcb60d00775407dc4fbacf247fbe0d7c1) [codex] Improve workspace navigation and runtime UI (#4089)
- [`057fee4`](https://github.com/paperclipai/paperclip/commit/057fee48365c1b58a52bf05ee2682c85a7e16103) [codex] Polish issue and operator workflow UI (#4090)
- [`16b2b84`](https://github.com/paperclipai/paperclip/commit/16b2b84d84c8ea73c38875aa9ae7da33dd24e3b7) [codex] Improve agent runtime recovery and governance (#4086)
- [`9c6f551`](https://github.com/paperclipai/paperclip/commit/9c6f55159503b4f091cf8102c1fe47d21e134c19) [codex] Add plugin orchestration host APIs (#4114)
- [`73eb237`](https://github.com/paperclipai/paperclip/commit/73eb23734f25c570d88665e672f80d740797c632) docs: use structured agent mentions in paperclip skill (#4103)
- [`0f4e4b4`](https://github.com/paperclipai/paperclip/commit/0f4e4b4c10c829adf2506d10d574a5bbe044bb7b) [codex] Split reusable agent hiring templates (#4124)
- [`4357a3f`](https://github.com/paperclipai/paperclip/commit/4357a3f352b6b6415dfdcb9e6f384da894a9c713) [codex] Harden dashboard run activity charts (#4126)
- [`56b3120`](https://github.com/paperclipai/paperclip/commit/56b31209715cf1b2f52b23cbadebcc407cf6d90a) [codex] Improve mobile org chart navigation (#4127)
- [`c7c1ca0`](https://github.com/paperclipai/paperclip/commit/c7c1ca0c78244c55699d29d62945b9eb13e38d90) [codex] Clean up terminal-result adapter process groups (#4129)
- [`549ef11`](https://github.com/paperclipai/paperclip/commit/549ef11c14b2b05f89220e80cecc41e78be95439) [codex] Respect manual workspace runtime controls (#4125)
- [`7a329fb`](https://github.com/paperclipai/paperclip/commit/7a329fb8bb9f74cdd75f3f7789c43fab0b2e7581) Harden API route authorization boundaries (#4122)
- [`2de893f`](https://github.com/paperclipai/paperclip/commit/2de893f624b181db027e087239282ce75d53064b) [codex] add comprehensive UI Storybook coverage (#4132)
- [`b94f1a1`](https://github.com/paperclipai/paperclip/commit/b94f1a156586ff8c7d1d121b37cee4fab321b029) chore(lockfile): refresh pnpm-lock.yaml (#4139)
- [`51f127f`](https://github.com/paperclipai/paperclip/commit/51f127f47bb1bcf1ba9e31670f4a8a403a4e9200) fix(hermes): stop advertising unsupported instructions bundles (#3908)
- [`1bf2424`](https://github.com/paperclipai/paperclip/commit/1bf242437780517f89e6d3f5981f945cf60a893d) fix: honor Hermes local command override (#3503)
- [`1266954`](https://github.com/paperclipai/paperclip/commit/1266954a4ee33ecca3589d47e4356fa1bdeaac5d) [codex] Make heartbeat scheduling blocker-aware (#4157)
- [`8d0c3d2`](https://github.com/paperclipai/paperclip/commit/8d0c3d2fe6dfda630e4c6f94a2eea2867cbbbc4b) fix(hermes): inject agent JWT into Hermes adapter env to fix identity attribution (#3608)
- [`1954eb3`](https://github.com/paperclipai/paperclip/commit/1954eb304867fdc3075d53529dd3a8edc5c10a2a) [codex] Detect issue graph liveness deadlocks (#4209)
- [`ab9051b`](https://github.com/paperclipai/paperclip/commit/ab9051b595be21dcfab93a4c02ff65548a6341ff) Add first-class issue references (#4214)
- [`09d0678`](https://github.com/paperclipai/paperclip/commit/09d0678840336094e70734ba429bc16bb1fd0940) [codex] Harden heartbeat scheduling and runtime controls (#4223)
- [`a26e128`](https://github.com/paperclipai/paperclip/commit/a26e1288b627e82c554445732c7d844648e6b5e1) [codex] Polish issue board workflows (#4224)
- [`73ef40e`](https://github.com/paperclipai/paperclip/commit/73ef40e7be9c31e70b1271bc873fcbe5d9a2d4e1) [codex] Sandbox dynamic adapter UI parsers (#4225)
- [`bcbbb41`](https://github.com/paperclipai/paperclip/commit/bcbbb41a4b25947e49329642923ab6b6a85853ae) [codex] Harden heartbeat runtime cleanup (#4233)
- [`014aa0e`](https://github.com/paperclipai/paperclip/commit/014aa0eb2d1425359313192141dc9b41285b8096) [codex] Clear stale queued comment targets (#4234)
- [`a957394`](https://github.com/paperclipai/paperclip/commit/a95739442027bdec8d291030a91e351dc434f635) [codex] Add structured issue-thread interactions (#4244)
- [`b69b563`](https://github.com/paperclipai/paperclip/commit/b69b563aa88af811ad45e658b0d8778ccb2f373d) [codex] Fix stale issue execution run locks (#4258)
- [`13551b2`](https://github.com/paperclipai/paperclip/commit/13551b2bac6e75fe879f9152ade60030467215cb) Add local environment lifecycle (#4297)
- [`2423207`](https://github.com/paperclipai/paperclip/commit/24232078fd64575a31713428c3df13e57dd66f38) fix(adapters/registry): honor module-provided sessionManagement for external adapters (#4296)
- [`3d15798`](https://github.com/paperclipai/paperclip/commit/3d15798c22535707cb1a26fb9ab61deecdc0171a) fix(adapters/routes): apply resolveExternalAdapterRegistration on hot-install (#4324)
- [`fe14de5`](https://github.com/paperclipai/paperclip/commit/fe14de504cdacc64cd58578c7d8617cd66ebe912) [codex] Document README architecture systems (#4250)
- [`854fa81`](https://github.com/paperclipai/paperclip/commit/854fa817573476186ce8b1e7a9afbcd3b71dd383) fix(pi-local): prepend installed skill bin/ dirs to child PATH (#4331)
- [`f98c348`](https://github.com/paperclipai/paperclip/commit/f98c348e2b3011b2fdc905c7a41f73d4f1998ac3) [codex] Add issue subtree pause, cancel, and restore controls (#4332)
- [`e4995bb`](https://github.com/paperclipai/paperclip/commit/e4995bbb1cc36454fc0fa3142ad9c7030c397ff0) Add SSH environment support (#4358)
- [`35a9dc3`](https://github.com/paperclipai/paperclip/commit/35a9dc37b00574c46e31fbd624c49ba1bc5de858) [codex] Speed up company skill detail loading (#4380)
- [`7ad225a`](https://github.com/paperclipai/paperclip/commit/7ad225a19830db2bc515e2049aa9ba38f2cdf87a) [codex] Improve issue thread review flow (#4381)
- [`4fdbbec`](https://github.com/paperclipai/paperclip/commit/4fdbbeced3da657de90c83e63f7243a35b360fef) [codex] Refine markdown issue reference rendering (#4382)
- [`8f1cd04`](https://github.com/paperclipai/paperclip/commit/8f1cd0474fa022363521191faf6bd44c71ec19b3) [codex] Improve transient recovery and Codex model refresh (#4383)
- [`77a72e2`](https://github.com/paperclipai/paperclip/commit/77a72e28c2ce328f44267c998df6a01c70b14de8) [codex] Polish issue composer and long document display (#4420)
- [`641eb44`](https://github.com/paperclipai/paperclip/commit/641eb449492ce39028ae06dcc5dd013d97cc3d85) [codex] Harden create-agent skill governance (#4422)
- [`70679a3`](https://github.com/paperclipai/paperclip/commit/70679a33216bae9247b1b6bddc5fcaad1c04e829) Add sandbox environment support (#4415)
- [`9a8d219`](https://github.com/paperclipai/paperclip/commit/9a8d2199492654930ba0864dd5c0757163998649) [codex] Stabilize tests and local maintenance assets (#4423)
- [`5a0c197`](https://github.com/paperclipai/paperclip/commit/5a0c1979cf439d434c527de4935687a178be4b8e) [codex] Add runtime lifecycle recovery and live issue visibility (#4419)
- [`0c6961a`](https://github.com/paperclipai/paperclip/commit/0c6961a03e5f7784af246baa4da868b85b9c6aa5) Normalize escaped multiline issue and approval text (#4444)
- [`6916e30`](https://github.com/paperclipai/paperclip/commit/6916e30f8ed440a0948255c96dc11251a098fb8d) Cancel stale retries when issue ownership changes (#4445)
- [`73fbdf3`](https://github.com/paperclipai/paperclip/commit/73fbdf36db15f7e1ef5eea0c9834804b0b54fd43) Gate stale-run watchdog decisions by board access (#4446)
- [`f68e9ca`](https://github.com/paperclipai/paperclip/commit/f68e9caa9ab6118ea656163a5f3ee73fcf3fbe0e) Polish markdown external link wrapping (#4447)
- [`deba60e`](https://github.com/paperclipai/paperclip/commit/deba60ebb23483c7316db95dccc1ea4218986578) Stabilize serialized server route tests (#4448)
- [`5bd0f57`](https://github.com/paperclipai/paperclip/commit/5bd0f578fd3f44aac910aab774443980696f4f97) Generalize sandbox provider core for plugin-only providers (#4449)
- [`4ef969f`](https://github.com/paperclipai/paperclip/commit/4ef969f0840810527333aa6ee44fed89f4551f7c) Add E2B sandbox provider plugin (#4452)
- [`40782f7`](https://github.com/paperclipai/paperclip/commit/40782f703d1f4a13f4ceadbe84c9b92be0bfacaf) Fix release packaging for standalone public packages (#4494)
- [`df425fd`](https://github.com/paperclipai/paperclip/commit/df425fde96903744347f4a006e0a9975904a2719) Present ordered sub-issues as a workflow checklist (#4523)
- [`c036bbf`](https://github.com/paperclipai/paperclip/commit/c036bbfa98494dcfe2521aab65019a4cd021c769) Add first-class security agent role to taxonomy (#4532)
- [`91333ec`](https://github.com/paperclipai/paperclip/commit/91333ec86f0509fa5688408d569ef551c60ae58b) feat: add paperclip-dev skill with optional bundled skill support (#3854)
- [`d148455`](https://github.com/paperclipai/paperclip/commit/d1484551eefb98321ce9153488ae644c59d256a7) Add open-source hygiene note to paperclip-dev skill (#4541)
- [`d47ffa8`](https://github.com/paperclipai/paperclip/commit/d47ffa87f07d380414976820a739f3e1daae174a) Fix CEO AGENT_HOME paths and centralize workspace env propagation (#4551)
- [`08af830`](https://github.com/paperclipai/paperclip/commit/08af83043076a95bc335a928826fca8117704594) Tighten publicBaseUrl port rewriting (#4553)
- [`b2496c8`](https://github.com/paperclipai/paperclip/commit/b2496c80672f15481f7af48952b0d6d68ec208de) fix(auth): trust allowed hostname port variants on detected listen port (#4554)
- [`54ab0d2`](https://github.com/paperclipai/paperclip/commit/54ab0d24cdf2ed37d55f93a819a59878f55868fb) Fix disappearing issue comments (#4557)
- [`8145141`](https://github.com/paperclipai/paperclip/commit/8145141c55f1a16f36be4787fe3bb46340d63553) Fix external issue URL rewriting in markdown (#4558)
- [`1d9f7a5`](https://github.com/paperclipai/paperclip/commit/1d9f7a5149fe60b66234d696f9ddc468e5afe19e) Fix flaky heartbeat recovery teardown CI failure (#4559)
- [`868d089`](https://github.com/paperclipai/paperclip/commit/868d08903e5ca6e45cf2921fc7cca90146a74790) test: isolate CLI company import e2e state (#4560)
- [`82e257c`](https://github.com/paperclipai/paperclip/commit/82e257c7baa5ff4747829215707721150d14a9a4) Cancel stale queued heartbeats when issue graph changes (PAP-2314) (#4534)
- [`d2cbe2c`](https://github.com/paperclipai/paperclip/commit/d2cbe2cb238deb685765942b93e67c9b1e835223) Prefer pushing feature branches to a user fork in paperclip-dev skill (#4572)
- [`1d8c7a0`](https://github.com/paperclipai/paperclip/commit/1d8c7a09b85b80eaa1616e302914b3d18bdc197f) [codex] Add security role route regression (#4586)
- [`f0f9460`](https://github.com/paperclipai/paperclip/commit/f0f9460d1d0132b0928732256dbbf158886c4ed5) docs: AWS ECS Fargate deployment runbook (#3897)
- [`fda296e`](https://github.com/paperclipai/paperclip/commit/fda296ee4f20768076eabc2f43c50fa6c6c5072c) [codex] Add configurable liveness auto-recovery controls (#4587)
- [`53396f2`](https://github.com/paperclipai/paperclip/commit/53396f272afb2ef059cf330f594fffda1ab9018a) [codex] Fix sub-issue progress summary styling (#4588)
- [`215b6cd`](https://github.com/paperclipai/paperclip/commit/215b6cd161c635b1549c3524286101e6ae4fe607) [codex] Add security role route coverage (#4589)
- [`ecd92af`](https://github.com/paperclipai/paperclip/commit/ecd92af001c4ae9830c9bedbd8ab2f622b9dad0f) release: v2026.427.0 notes (#4590)
- [`15c0ce3`](https://github.com/paperclipai/paperclip/commit/15c0ce37229a5b44ff25ac6186f21b7e9ea5cecb) Add Twitter/X link to READMEs (PAP-2475) (#4593)
- [`d95968a`](https://github.com/paperclipai/paperclip/commit/d95968a9f8ee79f527327bd6fb864a4325dd6fcb) [codex] Ignore stale stored company selections (#4602)
- [`6ccf80b`](https://github.com/paperclipai/paperclip/commit/6ccf80bcf2d26faccdb4eb21b0c324dc1aa32c45) [codex] Reject stale company skill refreshes (#4601)
- [`7a9b3a6`](https://github.com/paperclipai/paperclip/commit/7a9b3a6037110d022cd3ce5952878ed593949318) [codex] Harden recovery issue handling (#4600)
- [`68c3766`](https://github.com/paperclipai/paperclip/commit/68c37660f0fad7c92f58af6b7e6b6180c188f66f) Dispatch assigned todo work during recovery sweeps (#4614)
- [`f88f538`](https://github.com/paperclipai/paperclip/commit/f88f538e6d1b981d195c94b9d8efc7ae7ee52055) Keep manual routine runs visible in the runner inbox (#4615)
- [`43b0f2a`](https://github.com/paperclipai/paperclip/commit/43b0f2ae582b18f2872ae60bf468f54b99b614ba) Add pause and resume actions to sidebar agents (#4616)
- [`d0bdbe1`](https://github.com/paperclipai/paperclip/commit/d0bdbe11a9624435b6dca3968389bd59c6a559a2) Stabilize inline selector keyboard handling (#4617)

---

💬 **Reviewer:** comment `@gardener fix` after leaving feedback.
gardener will read your review, push a fix, and reply.
(Or just leave a review — gardener auto-checks every 30 minutes.)